### PR TITLE
Ensure DLL files in bin dir have unused symbols removed

### DIFF
--- a/8.9/package-vipsdev.sh
+++ b/8.9/package-vipsdev.sh
@@ -102,7 +102,7 @@ if [ "$type" = "shared" ]; then
   echo "Strip unneeded symbols"
 
   # Remove all symbols that are not needed
-  strip --strip-unneeded $repackage_dir/bin/*.exe
+  strip --strip-unneeded $repackage_dir/bin/*.{exe,dll}
 fi
 
 echo "Copying packaging files"


### PR DESCRIPTION
This is the approach taken by the non-mxe build - see https://github.com/libvips/build-win64/blob/master/8.9/package-vipsdev.sh#L74