### PR TITLE
Support llvm-mingw ARM/ARM64 targets in Rust

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@
 - [ ] Try to test the binaries with the Python test suite on Wine.
 - [ ] Incorporate the llvm-mingw toolchain plugin into MXE (see [mxe/mxe#2330](https://github.com/mxe/mxe/issues/2330)).
   - [x] Test the `armv7-w64-mingw32` target on a Raspberry Pi 3B with Windows 10 IoT.
-  - [ ] Test the `aarch64-w64-mingw32` target on a Raspberry Pi 4B with Windows 10 ARM64.
-  - [ ] The VIPS test suite should be able to run successfully on ARM/ARM64.
+  - [x] Test the `aarch64-w64-mingw32` target on a Raspberry Pi 4B with Windows 10 ARM64.
+  - [x] The VIPS test suite should be able to run successfully on ARM/ARM64.
   - [ ] Fix the llvm-mingw specific patches upstream or within LLVM.
-  - [ ] The Rust MinGW-w64 ARM/ARM64 targets are not yet supported, is there an alternative way to build librsvg for these architectures?
+  - [x] The Rust MinGW-w64 ARM/ARM64 targets are not yet supported, is there an alternative way to build librsvg for these architectures?

--- a/build/overrides.mk
+++ b/build/overrides.mk
@@ -552,6 +552,9 @@ define librsvg_BUILD
     $(SED) -i 's/45d980167c6b1a2fd54f045f39e6322a7739be6c4723b8c373716f8252d3778c/f769fd23b7389e684b2f365a9f1038273788eb0f3d5907fe34f7ac5383b0daf0/' '$(SOURCE_DIR)/vendor/cairo-rs/.cargo-checksum.json'
     $(SED) -i 's/d8c54bf5eeba9d035434da591646047329e0cad2c0be93c10409f7b36a0e55ec/b03f53a3c001dcd51fac158e8ca17f0c15299c77edba59444e91b73bc2b2226a/' '$(SOURCE_DIR)/vendor/cairo-sys-rs/.cargo-checksum.json'
 
+    # armv7 -> thumbv7a
+    $(eval ARCH_NAME := $(if $(findstring armv7,$(PROCESSOR)),thumbv7a,$(PROCESSOR)))
+
     cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure \
         $(MXE_CONFIGURE_OPTS) \
         --disable-pixbuf-loader \
@@ -560,7 +563,7 @@ define librsvg_BUILD
         --disable-nls \
         --without-libiconv-prefix \
         --without-libintl-prefix \
-        RUST_TARGET='$(PROCESSOR)-pc-windows-gnu' \
+        RUST_TARGET='$(ARCH_NAME)-pc-windows-gnu' \
         CARGO='$(TARGET)-cargo' \
         RUSTC='$(TARGET)-rustc'
 

--- a/build/patches/vips-8-fixes.patch
+++ b/build/patches/vips-8-fixes.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kleis Auke Wolthuizen <github@kleisauke.nl>
+Date: Fri, 25 Sep 2020 10:30:00 +0200
+Subject: [PATCH 1/1] Fix test failure on ARM-based Windows
+
+The optional parameters of vips_gaussnoise were incorrectly
+passed within vips_fractsurf. This was discovered when running
+the libvips testsuite on Windows 10 IoT (ARM32).
+
+diff --git a/libvips/create/fractsurf.c b/libvips/create/fractsurf.c
+index 1111111..2222222 100644
+--- a/libvips/create/fractsurf.c
++++ b/libvips/create/fractsurf.c
+@@ -74,8 +74,10 @@ vips_fractsurf_build( VipsObject *object )
+ 	if( VIPS_OBJECT_CLASS( vips_fractsurf_parent_class )->build( object ) )
+ 		return( -1 );
+ 
+-	if( vips_gaussnoise( &t[0], 
+-		fractsurf->width, fractsurf->height, 0.0, 1.0, NULL ) || 
++	if( vips_gaussnoise( &t[0], fractsurf->width, fractsurf->height,
++			"mean", 0.0,
++			"sigma", 1.0,
++			NULL ) || 
+ 		vips_mask_fractal( &t[1], fractsurf->width, fractsurf->height, 
+ 			fractsurf->fractal_dimension, NULL ) ||
+ 		vips_freqmult( t[0], t[1], &t[2], NULL ) ||

--- a/build/plugins/llvm-mingw/llvm-mingw.mk
+++ b/build/plugins/llvm-mingw/llvm-mingw.mk
@@ -17,9 +17,6 @@ $(PKG)_DEPS     := mingw-w64
 # https://github.com/mstorsjo/llvm-mingw/blob/master/build-mingw-w64.sh#L5-L6
 # Install the headers in $(PREFIX)/$(TARGET)/mingw since
 # we need to distribute the /include and /lib directories
-# Note: Building with --with-default-msvcrt=ucrt breaks
-# compatibility with the prebuilt Rust binaries that
-# is built in msvcrt mode.
 define $(PKG)_BUILD_mingw-w64
     # install the usual wrappers
     $($(PKG)_PRE_BUILD)
@@ -31,7 +28,7 @@ define $(PKG)_BUILD_mingw-w64
         --host='$(TARGET)' \
         --prefix='$(PREFIX)/$(TARGET)/mingw' \
         --enable-idl \
-        --with-default-msvcrt=msvcrt \
+        --with-default-msvcrt=ucrt \
         --with-default-win32-winnt=0x601 \
         $(mingw-w64-headers_CONFIGURE_OPTS)
     $(MAKE) -C '$(BUILD_DIR).headers' install
@@ -41,7 +38,7 @@ define $(PKG)_BUILD_mingw-w64
     cd '$(BUILD_DIR).crt' && '$(BUILD_DIR)/$(mingw-w64_SUBDIR)/mingw-w64-crt/configure' \
         --host='$(TARGET)' \
         --prefix='$(PREFIX)/$(TARGET)/mingw' \
-        --with-default-msvcrt=msvcrt \
+        --with-default-msvcrt=ucrt \
         @mingw-crt-config-opts@
     $(MAKE) -C '$(BUILD_DIR).crt' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR).crt' -j 1 $(INSTALL_STRIP_TOOLCHAIN)

--- a/build/plugins/llvm-mingw/overrides.mk
+++ b/build/plugins/llvm-mingw/overrides.mk
@@ -3,13 +3,7 @@ $(PLUGIN_HEADER)
 IS_LLVM := $(true)
 
 # Override sub-dependencies
-cc_DEPS := llvm
-
-# TODO: The armv7-pc-windows-gnu and aarch64-pc-windows-gnu Rust targets are not yet supported.
-librsvg_BUILD_aarch64-w64-mingw32 =
-librsvg_BUILD_armv7-w64-mingw32   =
-rust_BUILD_aarch64-w64-mingw32 =
-rust_BUILD_armv7-w64-mingw32   =
+cc_DEPS   := llvm
 
 # GCC does not support Windows on ARM
 gcc_BUILD_aarch64-w64-mingw32 =

--- a/build/plugins/llvm-mingw/patches/rust-1-fixes.patch
+++ b/build/plugins/llvm-mingw/patches/rust-1-fixes.patch
@@ -1,0 +1,343 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kleis Auke Wolthuizen <github@kleisauke.nl>
+Date: Tue, 15 Sep 2020 11:50:00 +0200
+Subject: [PATCH 1/6] Add llvm-mingw ARM/ARM64 targets
+
+
+diff --git a/compiler/rustc_target/src/spec/aarch64_pc_windows_gnu.rs b/compiler/rustc_target/src/spec/aarch64_pc_windows_gnu.rs
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/aarch64_pc_windows_gnu.rs
+@@ -0,0 +1,32 @@
++use crate::spec::{LinkerFlavor, LldFlavor, Target, TargetResult};
++
++pub fn target() -> TargetResult {
++    let mut base = super::windows_gnu_base::opts();
++
++    base.cpu = "generic".to_string();
++    base.pre_link_args
++        .insert(LinkerFlavor::Lld(LldFlavor::Ld), vec!["-m".to_string(), "arm64pe".to_string(),
++                                                       "-e".to_string(), "DllMainCRTStartup".to_string()]);
++    base.max_atomic_width = Some(64);
++    base.has_elf_tls = true;
++    base.linker = Some("ld.lld".to_string());
++
++    base.late_link_args
++        .get_mut(&LinkerFlavor::Lld(LldFlavor::Ld))
++        .unwrap()
++        .push("-lclang_rt.builtins-aarch64".to_string());
++
++    Ok(Target {
++        llvm_target: "aarch64-pc-windows-gnu".to_string(),
++        target_endian: "little".to_string(),
++        target_pointer_width: "64".to_string(),
++        target_c_int_width: "32".to_string(),
++        data_layout: "e-m:w-p:64:64-i32:32-i64:64-i128:128-n32:64-S128".to_string(),
++        arch: "aarch64".to_string(),
++        target_os: "windows".to_string(),
++        target_env: "gnu".to_string(),
++        target_vendor: "pc".to_string(),
++        linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
++        options: base,
++    })
++}
+diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
+index 1111111..2222222 100644
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -609,10 +609,12 @@ supported_targets! {
+ 
+     ("x86_64-unknown-illumos", x86_64_unknown_illumos),
+ 
++    ("aarch64-pc-windows-gnu", aarch64_pc_windows_gnu),
+     ("x86_64-pc-windows-gnu", x86_64_pc_windows_gnu),
+     ("i686-pc-windows-gnu", i686_pc_windows_gnu),
+     ("i686-uwp-windows-gnu", i686_uwp_windows_gnu),
+     ("x86_64-uwp-windows-gnu", x86_64_uwp_windows_gnu),
++    ("thumbv7a-pc-windows-gnu", thumbv7a_pc_windows_gnu),
+ 
+     ("aarch64-pc-windows-msvc", aarch64_pc_windows_msvc),
+     ("aarch64-uwp-windows-msvc", aarch64_uwp_windows_msvc),
+diff --git a/compiler/rustc_target/src/spec/thumbv7a_pc_windows_gnu.rs b/compiler/rustc_target/src/spec/thumbv7a_pc_windows_gnu.rs
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/thumbv7a_pc_windows_gnu.rs
+@@ -0,0 +1,32 @@
++use crate::spec::{LinkerFlavor, LldFlavor, Target, TargetResult};
++
++pub fn target() -> TargetResult {
++    let mut base = super::windows_gnu_base::opts();
++
++    base.cpu = "generic".to_string();
++    base.pre_link_args
++        .insert(LinkerFlavor::Lld(LldFlavor::Ld), vec!["-m".to_string(), "thumb2pe".to_string(),
++                                                       "-e".to_string(), "DllMainCRTStartup".to_string()]);
++    base.max_atomic_width = Some(64);
++    base.eliminate_frame_pointer = false; // Required for backtraces
++    base.linker = Some("ld.lld".to_string());
++
++    base.late_link_args
++        .get_mut(&LinkerFlavor::Lld(LldFlavor::Ld))
++        .unwrap()
++        .push("-lclang_rt.builtins-arm".to_string());
++
++    Ok(Target {
++        llvm_target: "thumbv7a-pc-windows-gnu".to_string(),
++        target_endian: "little".to_string(),
++        target_pointer_width: "32".to_string(),
++        target_c_int_width: "32".to_string(),
++        data_layout: "e-m:w-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
++        arch: "arm".to_string(),
++        target_os: "windows".to_string(),
++        target_env: "gnu".to_string(),
++        target_vendor: "pc".to_string(),
++        linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
++        options: base,
++    })
++}
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kleis Auke Wolthuizen <github@kleisauke.nl>
+Date: Tue, 15 Sep 2020 15:20:00 +0200
+Subject: [PATCH 2/6] Prefer linking against UCRT over MSVCRT
+
+When our linker is LLD (i.e. building with llvm-mingw).
+
+Also avoid linking against libgcc, libgcc_eh and libgcc_s.
+
+diff --git a/compiler/rustc_target/src/spec/windows_gnu_base.rs b/compiler/rustc_target/src/spec/windows_gnu_base.rs
+index 1111111..2222222 100644
+--- a/compiler/rustc_target/src/spec/windows_gnu_base.rs
++++ b/compiler/rustc_target/src/spec/windows_gnu_base.rs
+@@ -19,7 +19,7 @@ pub fn opts() -> TargetOptions {
+     let mut late_link_args_static = LinkArgs::new();
+     // Order of `late_link_args*` was found through trial and error to work with various
+     // mingw-w64 versions (not tested on the CI). It's expected to change from time to time.
+-    let mingw_libs = vec![
++    let mingw_libs_gcc = vec![
+         "-lmsvcrt".to_string(),
+         "-lmingwex".to_string(),
+         "-lmingw32".to_string(),
+@@ -34,8 +34,16 @@ pub fn opts() -> TargetOptions {
+         "-luser32".to_string(),
+         "-lkernel32".to_string(),
+     ];
+-    late_link_args.insert(LinkerFlavor::Gcc, mingw_libs.clone());
+-    late_link_args.insert(LinkerFlavor::Lld(LldFlavor::Ld), mingw_libs);
++    late_link_args.insert(LinkerFlavor::Gcc, mingw_libs_gcc);
++    let mingw_libs_llvm = vec![
++        "-lmingw32".to_string(),
++        "-lmingwex".to_string(),
++        "-lucrt".to_string(),
++        "-luser32".to_string(),
++        "-lkernel32".to_string(),
++        "-lunwind".to_string(),
++    ];
++    late_link_args.insert(LinkerFlavor::Lld(LldFlavor::Ld), mingw_libs_llvm);
+     let dynamic_unwind_libs = vec![
+         // If any of our crates are dynamically linked then we need to use
+         // the shared libgcc_s-dw2-1.dll. This is required to support
+@@ -44,8 +52,7 @@ pub fn opts() -> TargetOptions {
+         "-lgcc".to_string(),
+         "-lkernel32".to_string(),
+     ];
+-    late_link_args_dynamic.insert(LinkerFlavor::Gcc, dynamic_unwind_libs.clone());
+-    late_link_args_dynamic.insert(LinkerFlavor::Lld(LldFlavor::Ld), dynamic_unwind_libs);
++    late_link_args_dynamic.insert(LinkerFlavor::Gcc, dynamic_unwind_libs);
+     let static_unwind_libs = vec![
+         // If all of our crates are statically linked then we can get away
+         // with statically linking the libgcc unwinding code. This allows
+@@ -59,8 +66,7 @@ pub fn opts() -> TargetOptions {
+         "-lmsvcrt".to_string(),
+         "-lkernel32".to_string(),
+     ];
+-    late_link_args_static.insert(LinkerFlavor::Gcc, static_unwind_libs.clone());
+-    late_link_args_static.insert(LinkerFlavor::Lld(LldFlavor::Ld), static_unwind_libs);
++    late_link_args_static.insert(LinkerFlavor::Gcc, static_unwind_libs);
+ 
+     TargetOptions {
+         // FIXME(#13846) this should be enabled for windows
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kleis Auke Wolthuizen <github@kleisauke.nl>
+Date: Wed, 16 Sep 2020 09:30:00 +0200
+Subject: [PATCH 3/6] Make Windows GNU targets compatible with llvm-mingw
+
+
+diff --git a/compiler/rustc_target/src/spec/i686_pc_windows_gnu.rs b/compiler/rustc_target/src/spec/i686_pc_windows_gnu.rs
+index 1111111..2222222 100644
+--- a/compiler/rustc_target/src/spec/i686_pc_windows_gnu.rs
++++ b/compiler/rustc_target/src/spec/i686_pc_windows_gnu.rs
+@@ -4,7 +4,8 @@ pub fn target() -> TargetResult {
+     let mut base = super::windows_gnu_base::opts();
+     base.cpu = "pentium4".to_string();
+     base.pre_link_args
+-        .insert(LinkerFlavor::Lld(LldFlavor::Ld), vec!["-m".to_string(), "i386pe".to_string()]);
++        .insert(LinkerFlavor::Lld(LldFlavor::Ld), vec!["-m".to_string(), "i386pe".to_string(),
++                                                       "-e".to_string(), "_DllMainCRTStartup".to_string()]);
+     base.max_atomic_width = Some(64);
+     base.eliminate_frame_pointer = false; // Required for backtraces
+     base.linker = Some("i686-w64-mingw32-gcc".to_string());
+@@ -16,6 +17,11 @@ pub fn target() -> TargetResult {
+         .unwrap()
+         .push("-Wl,--large-address-aware".to_string());
+ 
++    base.late_link_args
++        .get_mut(&LinkerFlavor::Lld(LldFlavor::Ld))
++        .unwrap()
++        .push("-lclang_rt.builtins-i386".to_string());
++
+     Ok(Target {
+         llvm_target: "i686-pc-windows-gnu".to_string(),
+         target_endian: "little".to_string(),
+diff --git a/compiler/rustc_target/src/spec/x86_64_pc_windows_gnu.rs b/compiler/rustc_target/src/spec/x86_64_pc_windows_gnu.rs
+index 1111111..2222222 100644
+--- a/compiler/rustc_target/src/spec/x86_64_pc_windows_gnu.rs
++++ b/compiler/rustc_target/src/spec/x86_64_pc_windows_gnu.rs
+@@ -5,10 +5,16 @@ pub fn target() -> TargetResult {
+     base.cpu = "x86-64".to_string();
+     base.pre_link_args.get_mut(&LinkerFlavor::Gcc).unwrap().push("-m64".to_string());
+     base.pre_link_args
+-        .insert(LinkerFlavor::Lld(LldFlavor::Ld), vec!["-m".to_string(), "i386pep".to_string()]);
++        .insert(LinkerFlavor::Lld(LldFlavor::Ld), vec!["-m".to_string(), "i386pep".to_string(),
++                                                       "-e".to_string(), "DllMainCRTStartup".to_string()]);
+     base.max_atomic_width = Some(64);
+     base.linker = Some("x86_64-w64-mingw32-gcc".to_string());
+ 
++    base.late_link_args
++        .get_mut(&LinkerFlavor::Lld(LldFlavor::Ld))
++        .unwrap()
++        .push("-lclang_rt.builtins-x86_64".to_string());
++
+     Ok(Target {
+         llvm_target: "x86_64-pc-windows-gnu".to_string(),
+         target_endian: "little".to_string(),
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kleis Auke Wolthuizen <github@kleisauke.nl>
+Date: Fri, 18 Sep 2020 21:00:00 +0200
+Subject: [PATCH 4/6] Do not distribute Windows-specific files while
+ cross-compiling
+
+These files (gcc.exe, ld.exe, dlltool.exe, etc.) are not available on
+Unix systems with MinGW and probably exists only on MSYS environments.
+
+Note: this patch has only been tested on Linux.
+
+diff --git a/src/bootstrap/dist.rs b/src/bootstrap/dist.rs
+index 1111111..2222222 100644
+--- a/src/bootstrap/dist.rs
++++ b/src/bootstrap/dist.rs
+@@ -364,7 +364,7 @@ impl Step for Mingw {
+     fn run(self, builder: &Builder<'_>) -> Option<PathBuf> {
+         let host = self.host;
+ 
+-        if !host.contains("pc-windows-gnu") {
++        if !host.contains("pc-windows-gnu") || builder.config.build != host {
+             return None;
+         }
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kleis Auke Wolthuizen <github@kleisauke.nl>
+Date: Mon, 21 Sep 2020 11:00:00 +0200
+Subject: [PATCH 5/6] Ensure that compiler_builtins can be successfully built on
+ llvm-mingw
+
+Fixes an undefined symbol error while linking the compiler_builtins crate on
+llvm-mingw (targeting ARMv7).
+
+Details:
+lld-link: error: undefined symbol: __aeabi_idiv
+>>> referenced by libcompiler_builtins-<HASH>.rlib(<O_FILE>):(__aeabi_idivmod)
+
+diff --git a/vendor/compiler_builtins/build.rs b/vendor/compiler_builtins/build.rs
+index 1111111..2222222 100644
+--- a/vendor/compiler_builtins/build.rs
++++ b/vendor/compiler_builtins/build.rs
+@@ -303,7 +303,7 @@ mod c {
+             }
+         }
+ 
+-        if target_arch == "arm" && target_os != "ios" && target_env != "msvc" {
++        if target_arch == "arm" && target_os != "ios" && target_os != "windows" {
+             sources.extend(&[
+                 ("__aeabi_div0", "arm/aeabi_div0.c"),
+                 ("__aeabi_drsub", "arm/aeabi_drsub.c"),
+diff --git a/vendor/compiler_builtins/src/arm.rs b/vendor/compiler_builtins/src/arm.rs
+index 1111111..2222222 100644
+--- a/vendor/compiler_builtins/src/arm.rs
++++ b/vendor/compiler_builtins/src/arm.rs
+@@ -72,7 +72,7 @@ pub unsafe fn __aeabi_uldivmod() {
+     intrinsics::unreachable();
+ }
+ 
+-#[cfg(not(target_os = "ios"))]
++#[cfg(not(any(target_os = "ios", target_os = "windows")))]
+ #[naked]
+ #[cfg_attr(not(feature = "mangled-names"), no_mangle)]
+ pub unsafe fn __aeabi_idivmod() {
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kleis Auke Wolthuizen <github@kleisauke.nl>
+Date: Tue, 22 Sep 2020 10:00:00 +0200
+Subject: [PATCH 6/6] Ensure that panic_unwind/unwind can be successfully built on
+ llvm-mingw
+
+Fixes undefined symbol errors while linking these crates on llvm-mingw
+(targeting ARMv7).
+
+lld-link: error: undefined symbol: __gnu_unwind_frame
+>>> referenced by libpanic_unwind-<HASH>.rlib(<O_FILE>):(rust_eh_personality)
+>>> referenced by libpanic_unwind-<HASH>.rlib(<O_FILE>):(rust_eh_personality)
+
+lld-link: error: undefined symbol: _Unwind_VRS_Get
+>>> referenced by libunwind-<HASH>.rlib(<O_FILE>):(unwind::libunwind::_Unwind_GetGR::<HASH>)
+>>> referenced by libunwind-<HASH>.rlib(<O_FILE>):(unwind::libunwind::_Unwind_GetIP::<HASH>)
+>>> referenced by libunwind-<HASH>.rlib(<O_FILE>):(unwind::libunwind::_Unwind_SetIP::<HASH>)
+>>> referenced 1 more times
+
+lld-link: error: undefined symbol: _Unwind_VRS_Set
+>>> referenced by libunwind-<HASH>.rlib(<O_FILE>):(unwind::libunwind::_Unwind_SetGR::<HASH>)
+>>> referenced by libunwind-<HASH>.rlib(<O_FILE>):(unwind::libunwind::_Unwind_SetIP::<HASH>)
+
+diff --git a/library/panic_unwind/src/gcc.rs b/library/panic_unwind/src/gcc.rs
+index 1111111..2222222 100644
+--- a/library/panic_unwind/src/gcc.rs
++++ b/library/panic_unwind/src/gcc.rs
+@@ -128,7 +128,7 @@ const UNWIND_DATA_REG: (i32, i32) = (10, 11); // x10, x11
+ // https://github.com/gcc-mirror/gcc/blob/trunk/libgcc/unwind-c.c
+ 
+ cfg_if::cfg_if! {
+-    if #[cfg(all(target_arch = "arm", not(target_os = "ios"), not(target_os = "netbsd")))] {
++    if #[cfg(all(target_arch = "arm", not(target_os = "ios"), not(target_os = "netbsd"), not(target_os = "windows")))] {
+         // ARM EHABI personality routine.
+         // http://infocenter.arm.com/help/topic/com.arm.doc.ihi0038b/IHI0038B_ehabi.pdf
+         //
+diff --git a/library/unwind/src/libunwind.rs b/library/unwind/src/libunwind.rs
+index 1111111..2222222 100644
+--- a/library/unwind/src/libunwind.rs
++++ b/library/unwind/src/libunwind.rs
+@@ -89,7 +89,7 @@ extern "C" {
+ }
+ 
+ cfg_if::cfg_if! {
+-if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm"))))] {
++if #[cfg(all(any(target_os = "ios", target_os = "netbsd", target_os = "windows", not(target_arch = "arm"))))] {
+     // Not ARM EHABI
+     #[repr(C)]
+     #[derive(Copy, Clone, PartialEq)]
+@@ -103,7 +103,7 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
+     pub use _Unwind_Action::*;
+ 
+     #[cfg_attr(all(feature = "llvm-libunwind",
+-                   any(target_os = "fuchsia", target_os = "linux")),
++                   any(target_os = "fuchsia", target_os = "linux", target_os = "windows")),
+                link(name = "unwind", kind = "static"))]
+     extern "C" {
+         pub fn _Unwind_GetGR(ctx: *mut _Unwind_Context, reg_index: c_int) -> _Unwind_Word;

--- a/build/plugins/llvm-mingw/rust.mk
+++ b/build/plugins/llvm-mingw/rust.mk
@@ -1,0 +1,147 @@
+PKG             := rust
+$(PKG)_WEBSITE  := https://www.rust-lang.org/
+$(PKG)_DESCR    := A systems programming language focused on safety, speed and concurrency.
+$(PKG)_IGNORE   :=
+# https://static.rust-lang.org/dist/2020-09-27/rustc-nightly-src.tar.gz.sha256
+$(PKG)_VERSION  := nightly
+$(PKG)_CHECKSUM := b5ab3cb836264482c7984cb0eec08a23a34bad29d6e55c416800d3430c550855
+$(PKG)_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/$(PKG)-[0-9]*.patch)))
+$(PKG)_SUBDIR   := $(PKG)c-$($(PKG)_VERSION)-src
+$(PKG)_FILE     := $(PKG)c-$($(PKG)_VERSION)-src.tar.gz
+$(PKG)_URL      := https://static.rust-lang.org/dist/2020-09-27/$($(PKG)_FILE)
+$(PKG)_DEPS     := $(BUILD)~$(PKG)
+$(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
+
+$(PKG)_DEPS_$(BUILD) := $(BUILD)~llvm
+
+export RUST_TARGET_PATH := $(dir $(lastword $(MAKEFILE_LIST)))/rust
+
+# Build Rust from source to support the ARM targets and
+# to ensure that it links against UCRT (the prebuilt Rust
+# binaries are built with --with-default-msvcrt=msvcrt)
+define $(PKG)_BUILD_$(BUILD)
+    # x86_64-pc-linux-gnu -> x86_64-unknown-linux-gnu
+    $(eval BUILD_RUST := $(firstword $(subst -, ,$(BUILD)))-unknown-linux-gnu)
+
+    # Disable LTO, panic strategy and optimization settings while
+    # we bootstrap Rust
+    $(eval unexport CARGO_PROFILE_RELEASE_LTO)
+    $(eval unexport CARGO_PROFILE_RELEASE_OPT_LEVEL)
+    $(eval unexport CARGO_PROFILE_RELEASE_PANIC)
+
+    # Don't depend on a nightly version of rustfmt
+    $(SED) -i '/^rustfmt:/d' $(SOURCE_DIR)/src/stage0.txt
+
+    cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure \
+        --prefix='$(PREFIX)/$(BUILD)' \
+        --release-channel=nightly \
+        --enable-extended \
+        --tools=cargo,src \
+        --disable-docs \
+        --disable-codegen-tests \
+        --python='$(PYTHON2)' \
+        --llvm-root='$(PREFIX)/$(BUILD)' \
+        --set target.$(BUILD_RUST).cc='$(BUILD_CC)' \
+        --set target.$(BUILD_RUST).cxx='$(BUILD_CXX)' \
+        --set target.$(BUILD_RUST).ar='$(PREFIX)/$(BUILD)/bin/llvm-ar' \
+        --set target.$(BUILD_RUST).ranlib='$(PREFIX)/$(BUILD)/bin/llvm-ranlib'
+
+    # Enable networking while we build Rust from source. Assumes
+    # that the Rust build is reproducible.
+    echo 'static int __attribute__((unused)) _dummy;' > '$(BUILD_DIR)/dummy.c'
+    $(BUILD_CC) -shared -fPIC $(NONET_CFLAGS) -o $(NONET_LIB) $(BUILD_DIR)/dummy.c
+
+    # Build Rust
+    cd '$(BUILD_DIR)' && \
+        $(PYTHON2) $(SOURCE_DIR)/x.py build -j '$(JOBS)' -v
+
+    # Install Rust
+    cd '$(BUILD_DIR)' && \
+        $(PYTHON2) $(SOURCE_DIR)/x.py install --keep-stage 1 -j '$(JOBS)' -v
+
+    # Disable networking (again) for reproducible builds further on
+    $(BUILD_CC) -shared -fPIC $(NONET_CFLAGS) -o $(NONET_LIB) $(TOP_DIR)/tools/nonetwork.c
+endef
+
+# Build the standard library of Rust using the build-std feature
+define $(PKG)_BUILD
+    # armv7 -> thumbv7a
+    $(eval ARCH_NAME := $(if $(findstring armv7,$(PROCESSOR)),thumbv7a,$(PROCESSOR)))
+    $(eval TARGET_RUST := $(ARCH_NAME)-pc-windows-gnu)
+
+    # [major].[minor].[patch]-[label] -> [major].[minor].[patch]
+    $(eval CLANG_VERSION := $(firstword $(subst -, ,$(clang_VERSION))))
+
+    # Flags we use to build the standard library
+    # Note: libstd must be built with bitcode (-Cembed-bitcode=yes) so that the produced
+    # rlibs can be used for LTO builds.
+    # Note 2: -Clinker-flavor=ld.lld will force LLD as linker flavor for targets that
+    # have not set this by default (i.e. {i686,x86_64}-pc-windows-gnu).
+    # Note 3: -Clink-self-contained=yes will link against the {,dll}crt2.o (defined in
+    # pre_link_objects_fallback) from our MinGW distribution.
+    # Note 4: The -Clink-arg=* options adds our MinGW distribution and the compiler-rt
+    # builtins to the standard set of searched paths.
+    $(eval STD_FLAGS := -Cembed-bitcode=yes \
+                        -Clinker=ld.lld \
+                        -Clinker-flavor=ld.lld \
+                        -Clink-self-contained=yes \
+                        -Clink-arg=-L$(PREFIX)/$(TARGET)/lib \
+                        -Clink-arg=-L$(PREFIX)/$(TARGET)/mingw/lib \
+                        -Clink-arg=-L$(PREFIX)/$(BUILD)/lib/clang/$(CLANG_VERSION)/lib/windows)
+
+    # Hint the C/C++ compiler and archiver for this target
+    $(eval export CC_$(TARGET_RUST)  := $(TARGET)-clang)
+    $(eval export CXX_$(TARGET_RUST) := $(TARGET)-clang++)
+    $(eval export AR_$(TARGET_RUST)  := $(PREFIX)/$(BUILD)/bin/llvm-ar)
+
+    # Disable "fat" LTO while we build the standard library
+    $(eval unexport CARGO_PROFILE_RELEASE_LTO)
+
+    # Enable networking while we build the standard library
+    echo 'static int __attribute__((unused)) _dummy;' > '$(BUILD_DIR)/dummy.c'
+    $(BUILD_CC) -shared -fPIC $(NONET_CFLAGS) -o $(NONET_LIB) $(BUILD_DIR)/dummy.c
+
+    # Create a new temporary Cargo package
+    CARGO_NAME=dummy \
+    $(PREFIX)/$(BUILD)/bin/cargo init '$(BUILD_DIR)' --name dummy --vcs none --lib
+
+    # Build and prepare startup objects like rsbegin.o and rsend.o
+    $(foreach FILE, rsbegin rsend, \
+        RUSTC_BOOTSTRAP=1 \
+        $(PREFIX)/$(BUILD)/bin/rustc --cfg bootstrap --target $(TARGET_RUST) --emit=obj -o '$(BUILD_DIR)/$(FILE).o' \
+            '$(PREFIX)/$(BUILD)/lib/rustlib/src/rust/library/rtstartup/$(FILE).rs';)
+
+    # Build the standard library
+    cd '$(BUILD_DIR)' && \
+        RUSTFLAGS='$(STD_FLAGS)' \
+        $(PREFIX)/$(BUILD)/bin/cargo build -Zbuild-std=panic_abort,std --release --target $(TARGET_RUST)
+
+    # Disable networking (again) for reproducible builds further on
+    $(BUILD_CC) -shared -fPIC $(NONET_CFLAGS) -o $(NONET_LIB) $(TOP_DIR)/tools/nonetwork.c
+
+    # Install the standard library
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/rustlib/$(TARGET_RUST)/lib'
+    mv -vf '$(BUILD_DIR)/target/$(TARGET_RUST)/release/deps/'*.{rlib,rmeta} \
+        '$(PREFIX)/$(TARGET)/lib/rustlib/$(TARGET_RUST)/lib'
+
+    # Install Cargo config
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/.cargo'
+    (echo '[build]'; \
+     echo 'target = "$(TARGET_RUST)"'; \
+     echo 'rustflags = ['; \
+     echo '    "--sysroot",'; \
+     echo '    "$(PREFIX)/$(TARGET)"'; \
+     echo ']';) \
+             > '$(PREFIX)/$(TARGET)/.cargo/config'
+
+    # Install prefixed wrappers
+    (echo '#!/usr/bin/env bash'; \
+     echo 'CARGO_HOME="$(PREFIX)/$(TARGET)/.cargo" \'; \
+     echo 'RUSTC="$(PREFIX)/bin/$(TARGET)-rustc" \'; \
+     echo 'exec $(PREFIX)/$(BUILD)/bin/cargo \'; \
+     echo '"$$@"';) \
+             > '$(PREFIX)/bin/$(TARGET)-cargo'
+    chmod 0755 '$(PREFIX)/bin/$(TARGET)-cargo'
+
+    ln -sf '$(PREFIX)/$(BUILD)/bin/rustc' '$(PREFIX)/bin/$(TARGET)-rustc'
+endef

--- a/build/plugins/llvm-mingw/rust/aarch64-pc-windows-gnu.json
+++ b/build/plugins/llvm-mingw/rust/aarch64-pc-windows-gnu.json
@@ -1,0 +1,142 @@
+{
+  "abi-return-struct-as-int": true,
+  "allows-weak-linkage": false,
+  "arch": "aarch64",
+  "cpu": "generic",
+  "crt-objects-fallback": "mingw",
+  "data-layout": "e-m:w-p:64:64-i32:32-i64:64-i128:128-n32:64-S128",
+  "dll-prefix": "",
+  "dll-suffix": ".dll",
+  "dynamic-linking": true,
+  "eh-frame-header": false,
+  "emit-debug-gdb-scripts": false,
+  "env": "gnu",
+  "exe-suffix": ".exe",
+  "executables": true,
+  "function-sections": false,
+  "has-elf-tls": true,
+  "is-builtin": true,
+  "is-like-windows": true,
+  "late-link-args": {
+    "ld.lld": [
+      "-lmingw32",
+      "-lmingwex",
+      "-lucrt",
+      "-luser32",
+      "-lkernel32",
+      "-lunwind",
+      "-lclang_rt.builtins-aarch64"
+    ]
+  },
+  "late-link-args-dynamic": {
+    "ld.lld": []
+  },
+  "late-link-args-static": {
+    "ld.lld": []
+  },
+  "linker": "ld.lld",
+  "linker-flavor": "ld.lld",
+  "llvm-target": "aarch64-pc-windows-gnu",
+  "max-atomic-width": 64,
+  "os": "windows",
+  "post-link-objects": {
+    "dynamic-dylib": [
+      "rsend.o"
+    ],
+    "dynamic-nopic-exe": [
+      "rsend.o"
+    ],
+    "dynamic-pic-exe": [
+      "rsend.o"
+    ],
+    "static-dylib": [
+      "rsend.o"
+    ],
+    "static-nopic-exe": [
+      "rsend.o"
+    ],
+    "static-pic-exe": [
+      "rsend.o"
+    ]
+  },
+  "post-link-objects-fallback": {
+    "dynamic-dylib": [
+      "rsend.o"
+    ],
+    "dynamic-nopic-exe": [
+      "rsend.o"
+    ],
+    "dynamic-pic-exe": [
+      "rsend.o"
+    ],
+    "static-dylib": [
+      "rsend.o"
+    ],
+    "static-nopic-exe": [
+      "rsend.o"
+    ],
+    "static-pic-exe": [
+      "rsend.o"
+    ]
+  },
+  "pre-link-args": {
+    "ld.lld": [
+      "-m",
+      "arm64pe",
+      "-e",
+      "DllMainCRTStartup"
+    ]
+  },
+  "pre-link-objects": {
+    "dynamic-dylib": [
+      "rsbegin.o"
+    ],
+    "dynamic-nopic-exe": [
+      "rsbegin.o"
+    ],
+    "dynamic-pic-exe": [
+      "rsbegin.o"
+    ],
+    "static-dylib": [
+      "rsbegin.o"
+    ],
+    "static-nopic-exe": [
+      "rsbegin.o"
+    ],
+    "static-pic-exe": [
+      "rsbegin.o"
+    ]
+  },
+  "pre-link-objects-fallback": {
+    "dynamic-dylib": [
+      "dllcrt2.o",
+      "rsbegin.o"
+    ],
+    "dynamic-nopic-exe": [
+      "crt2.o",
+      "rsbegin.o"
+    ],
+    "dynamic-pic-exe": [
+      "crt2.o",
+      "rsbegin.o"
+    ],
+    "static-dylib": [
+      "dllcrt2.o",
+      "rsbegin.o"
+    ],
+    "static-nopic-exe": [
+      "crt2.o",
+      "rsbegin.o"
+    ],
+    "static-pic-exe": [
+      "crt2.o",
+      "rsbegin.o"
+    ]
+  },
+  "requires-uwtable": true,
+  "target-c-int-width": "32",
+  "target-endian": "little",
+  "target-family": "windows",
+  "target-pointer-width": "64",
+  "vendor": "pc"
+}

--- a/build/plugins/llvm-mingw/rust/i686-pc-windows-gnu.json
+++ b/build/plugins/llvm-mingw/rust/i686-pc-windows-gnu.json
@@ -1,0 +1,142 @@
+{
+  "abi-return-struct-as-int": true,
+  "allows-weak-linkage": false,
+  "arch": "x86",
+  "cpu": "pentium4",
+  "crt-objects-fallback": "mingw",
+  "data-layout": "e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:32-n8:16:32-a:0:32-S32",
+  "dll-prefix": "",
+  "dll-suffix": ".dll",
+  "dynamic-linking": true,
+  "eh-frame-header": false,
+  "eliminate-frame-pointer": false,
+  "emit-debug-gdb-scripts": false,
+  "env": "gnu",
+  "exe-suffix": ".exe",
+  "executables": true,
+  "function-sections": false,
+  "is-builtin": true,
+  "is-like-windows": true,
+  "late-link-args": {
+    "ld.lld": [
+      "-lmingw32",
+      "-lmingwex",
+      "-lucrt",
+      "-luser32",
+      "-lkernel32",
+      "-lunwind",
+      "-lclang_rt.builtins-i386"
+    ]
+  },
+  "late-link-args-dynamic": {
+    "ld.lld": []
+  },
+  "late-link-args-static": {
+    "ld.lld": []
+  },
+  "linker": "ld.lld",
+  "linker-flavor": "ld.lld",
+  "llvm-target": "i686-pc-windows-gnu",
+  "max-atomic-width": 64,
+  "os": "windows",
+  "post-link-objects": {
+    "dynamic-dylib": [
+      "rsend.o"
+    ],
+    "dynamic-nopic-exe": [
+      "rsend.o"
+    ],
+    "dynamic-pic-exe": [
+      "rsend.o"
+    ],
+    "static-dylib": [
+      "rsend.o"
+    ],
+    "static-nopic-exe": [
+      "rsend.o"
+    ],
+    "static-pic-exe": [
+      "rsend.o"
+    ]
+  },
+  "post-link-objects-fallback": {
+    "dynamic-dylib": [
+      "rsend.o"
+    ],
+    "dynamic-nopic-exe": [
+      "rsend.o"
+    ],
+    "dynamic-pic-exe": [
+      "rsend.o"
+    ],
+    "static-dylib": [
+      "rsend.o"
+    ],
+    "static-nopic-exe": [
+      "rsend.o"
+    ],
+    "static-pic-exe": [
+      "rsend.o"
+    ]
+  },
+  "pre-link-args": {
+    "ld.lld": [
+      "-m",
+      "i386pe",
+      "-e",
+      "_DllMainCRTStartup"
+    ]
+  },
+  "pre-link-objects": {
+    "dynamic-dylib": [
+      "rsbegin.o"
+    ],
+    "dynamic-nopic-exe": [
+      "rsbegin.o"
+    ],
+    "dynamic-pic-exe": [
+      "rsbegin.o"
+    ],
+    "static-dylib": [
+      "rsbegin.o"
+    ],
+    "static-nopic-exe": [
+      "rsbegin.o"
+    ],
+    "static-pic-exe": [
+      "rsbegin.o"
+    ]
+  },
+  "pre-link-objects-fallback": {
+    "dynamic-dylib": [
+      "dllcrt2.o",
+      "rsbegin.o"
+    ],
+    "dynamic-nopic-exe": [
+      "crt2.o",
+      "rsbegin.o"
+    ],
+    "dynamic-pic-exe": [
+      "crt2.o",
+      "rsbegin.o"
+    ],
+    "static-dylib": [
+      "dllcrt2.o",
+      "rsbegin.o"
+    ],
+    "static-nopic-exe": [
+      "crt2.o",
+      "rsbegin.o"
+    ],
+    "static-pic-exe": [
+      "crt2.o",
+      "rsbegin.o"
+    ]
+  },
+  "requires-uwtable": true,
+  "target-c-int-width": "32",
+  "target-endian": "little",
+  "target-family": "windows",
+  "target-pointer-width": "32",
+  "vendor": "pc"
+}

--- a/build/plugins/llvm-mingw/rust/thumbv7a-pc-windows-gnu.json
+++ b/build/plugins/llvm-mingw/rust/thumbv7a-pc-windows-gnu.json
@@ -1,0 +1,142 @@
+{
+  "abi-return-struct-as-int": true,
+  "allows-weak-linkage": false,
+  "arch": "arm",
+  "cpu": "generic",
+  "crt-objects-fallback": "mingw",
+  "data-layout": "e-m:w-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64",
+  "dll-prefix": "",
+  "dll-suffix": ".dll",
+  "dynamic-linking": true,
+  "eh-frame-header": false,
+  "eliminate-frame-pointer": false,
+  "emit-debug-gdb-scripts": false,
+  "env": "gnu",
+  "exe-suffix": ".exe",
+  "executables": true,
+  "function-sections": false,
+  "is-builtin": true,
+  "is-like-windows": true,
+  "late-link-args": {
+    "ld.lld": [
+      "-lmingw32",
+      "-lmingwex",
+      "-lucrt",
+      "-luser32",
+      "-lkernel32",
+      "-lunwind",
+      "-lclang_rt.builtins-arm"
+    ]
+  },
+  "late-link-args-dynamic": {
+    "ld.lld": []
+  },
+  "late-link-args-static": {
+    "ld.lld": []
+  },
+  "linker": "ld.lld",
+  "linker-flavor": "ld.lld",
+  "llvm-target": "thumbv7a-pc-windows-gnu",
+  "max-atomic-width": 64,
+  "os": "windows",
+  "post-link-objects": {
+    "dynamic-dylib": [
+      "rsend.o"
+    ],
+    "dynamic-nopic-exe": [
+      "rsend.o"
+    ],
+    "dynamic-pic-exe": [
+      "rsend.o"
+    ],
+    "static-dylib": [
+      "rsend.o"
+    ],
+    "static-nopic-exe": [
+      "rsend.o"
+    ],
+    "static-pic-exe": [
+      "rsend.o"
+    ]
+  },
+  "post-link-objects-fallback": {
+    "dynamic-dylib": [
+      "rsend.o"
+    ],
+    "dynamic-nopic-exe": [
+      "rsend.o"
+    ],
+    "dynamic-pic-exe": [
+      "rsend.o"
+    ],
+    "static-dylib": [
+      "rsend.o"
+    ],
+    "static-nopic-exe": [
+      "rsend.o"
+    ],
+    "static-pic-exe": [
+      "rsend.o"
+    ]
+  },
+  "pre-link-args": {
+    "ld.lld": [
+      "-m",
+      "thumb2pe",
+      "-e",
+      "DllMainCRTStartup"
+    ]
+  },
+  "pre-link-objects": {
+    "dynamic-dylib": [
+      "rsbegin.o"
+    ],
+    "dynamic-nopic-exe": [
+      "rsbegin.o"
+    ],
+    "dynamic-pic-exe": [
+      "rsbegin.o"
+    ],
+    "static-dylib": [
+      "rsbegin.o"
+    ],
+    "static-nopic-exe": [
+      "rsbegin.o"
+    ],
+    "static-pic-exe": [
+      "rsbegin.o"
+    ]
+  },
+  "pre-link-objects-fallback": {
+    "dynamic-dylib": [
+      "dllcrt2.o",
+      "rsbegin.o"
+    ],
+    "dynamic-nopic-exe": [
+      "crt2.o",
+      "rsbegin.o"
+    ],
+    "dynamic-pic-exe": [
+      "crt2.o",
+      "rsbegin.o"
+    ],
+    "static-dylib": [
+      "dllcrt2.o",
+      "rsbegin.o"
+    ],
+    "static-nopic-exe": [
+      "crt2.o",
+      "rsbegin.o"
+    ],
+    "static-pic-exe": [
+      "crt2.o",
+      "rsbegin.o"
+    ]
+  },
+  "requires-uwtable": true,
+  "target-c-int-width": "32",
+  "target-endian": "little",
+  "target-family": "windows",
+  "target-pointer-width": "32",
+  "vendor": "pc"
+}

--- a/build/plugins/llvm-mingw/rust/x86_64_pc_windows_gnu.json
+++ b/build/plugins/llvm-mingw/rust/x86_64_pc_windows_gnu.json
@@ -1,0 +1,141 @@
+{
+  "abi-return-struct-as-int": true,
+  "allows-weak-linkage": false,
+  "arch": "x86_64",
+  "cpu": "x86-64",
+  "crt-objects-fallback": "mingw",
+  "data-layout": "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  "dll-prefix": "",
+  "dll-suffix": ".dll",
+  "dynamic-linking": true,
+  "eh-frame-header": false,
+  "emit-debug-gdb-scripts": false,
+  "env": "gnu",
+  "exe-suffix": ".exe",
+  "executables": true,
+  "function-sections": false,
+  "is-builtin": true,
+  "is-like-windows": true,
+  "late-link-args": {
+    "ld.lld": [
+      "-lmingw32",
+      "-lmingwex",
+      "-lucrt",
+      "-luser32",
+      "-lkernel32",
+      "-lunwind",
+      "-lclang_rt.builtins-x86_64"
+    ]
+  },
+  "late-link-args-dynamic": {
+    "ld.lld": []
+  },
+  "late-link-args-static": {
+    "ld.lld": []
+  },
+  "linker": "ld.lld",
+  "linker-flavor": "ld.lld",
+  "llvm-target": "x86_64-pc-windows-gnu",
+  "max-atomic-width": 64,
+  "os": "windows",
+  "post-link-objects": {
+    "dynamic-dylib": [
+      "rsend.o"
+    ],
+    "dynamic-nopic-exe": [
+      "rsend.o"
+    ],
+    "dynamic-pic-exe": [
+      "rsend.o"
+    ],
+    "static-dylib": [
+      "rsend.o"
+    ],
+    "static-nopic-exe": [
+      "rsend.o"
+    ],
+    "static-pic-exe": [
+      "rsend.o"
+    ]
+  },
+  "post-link-objects-fallback": {
+    "dynamic-dylib": [
+      "rsend.o"
+    ],
+    "dynamic-nopic-exe": [
+      "rsend.o"
+    ],
+    "dynamic-pic-exe": [
+      "rsend.o"
+    ],
+    "static-dylib": [
+      "rsend.o"
+    ],
+    "static-nopic-exe": [
+      "rsend.o"
+    ],
+    "static-pic-exe": [
+      "rsend.o"
+    ]
+  },
+  "pre-link-args": {
+    "ld.lld": [
+      "-m",
+      "i386pep",
+      "-e",
+      "DllMainCRTStartup"
+    ]
+  },
+  "pre-link-objects": {
+    "dynamic-dylib": [
+      "rsbegin.o"
+    ],
+    "dynamic-nopic-exe": [
+      "rsbegin.o"
+    ],
+    "dynamic-pic-exe": [
+      "rsbegin.o"
+    ],
+    "static-dylib": [
+      "rsbegin.o"
+    ],
+    "static-nopic-exe": [
+      "rsbegin.o"
+    ],
+    "static-pic-exe": [
+      "rsbegin.o"
+    ]
+  },
+  "pre-link-objects-fallback": {
+    "dynamic-dylib": [
+      "dllcrt2.o",
+      "rsbegin.o"
+    ],
+    "dynamic-nopic-exe": [
+      "crt2.o",
+      "rsbegin.o"
+    ],
+    "dynamic-pic-exe": [
+      "crt2.o",
+      "rsbegin.o"
+    ],
+    "static-dylib": [
+      "dllcrt2.o",
+      "rsbegin.o"
+    ],
+    "static-nopic-exe": [
+      "crt2.o",
+      "rsbegin.o"
+    ],
+    "static-pic-exe": [
+      "crt2.o",
+      "rsbegin.o"
+    ]
+  },
+  "requires-uwtable": true,
+  "target-c-int-width": "32",
+  "target-endian": "little",
+  "target-family": "windows",
+  "target-pointer-width": "64",
+  "vendor": "pc"
+}

--- a/build/rust-std-aarch64.mk
+++ b/build/rust-std-aarch64.mk
@@ -1,8 +1,0 @@
-# TODO: The aarch64-pc-windows-gnu Rust target is not yet supported.
-
-PKG             := rust-std-aarch64
-$(PKG)_WEBSITE  := https://www.rust-lang.org/
-$(PKG)_DESCR    := A systems programming language focused on safety, speed and concurrency.
-$(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 1.46.0
-$(PKG)_TYPE     := meta

--- a/build/rust-std-armv7.mk
+++ b/build/rust-std-armv7.mk
@@ -1,8 +1,0 @@
-# TODO: The armv7-pc-windows-gnu Rust target is not yet supported.
-
-PKG             := rust-std-armv7
-$(PKG)_WEBSITE  := https://www.rust-lang.org/
-$(PKG)_DESCR    := A systems programming language focused on safety, speed and concurrency.
-$(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 1.46.0
-$(PKG)_TYPE     := meta


### PR DESCRIPTION
This PR adds support for building librsvg for the llvm-mingw ARM/ARM64 targets by compiling the nightly version of Rust and using the [`build-std` feature](https://github.com/rust-lang/wg-cargo-std-aware) to compile the standard library itself. This approach makes us independent of the prebuilt binaries provided by Rust and allows us to safely use UCRT as default CRT library (instead than MSVCRT).

A small amount of patches against Rust makes this possible, some of them are incompatible with the GCC targets that Rust provides. For example, it removes the need of linking against `libgcc`, `libgcc_eh` and `libgcc_s` and it forces the entry point to `DllMainCRTStartup` (or `_DllMainCRTStartup` for i686) located in MinGW. This works for our use-case, but might break when building Rust executables our using LLD in combination with GCC.

Resolves: https://github.com/libvips/build-win64-mxe/issues/12.
Stacked on top of: https://github.com/libvips/build-win64-mxe/pull/14.