### PR TITLE
aom: build without HDR/WebM, reduce binary size by ~8%

### DIFF
--- a/build/aom.mk
+++ b/build/aom.mk
@@ -13,6 +13,8 @@ define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && NASM_PATH='$(PREFIX)/$(BUILD)/bin' $(TARGET)-cmake \
         -DENABLE_NASM=ON \
         -DENABLE_TESTS=OFF \
+        -DCONFIG_AV1_HIGHBITDEPTH=0 \
+        -DCONFIG_WEBM_IO=0 \
         $(if $(IS_ARM), -DCONFIG_RUNTIME_CPU_DETECT=0) \
         $(if $(IS_GCC), -DCONFIG_PIC=1) \
         $(if $(call seq,i686,$(PROCESSOR)), -DAOM_TARGET_CPU='x86') \


### PR DESCRIPTION
As discussed in https://github.com/lovell/sharp-libvips/pull/94

Before and after for `web x86_64 static` build:
```
 27132928  vips-dev-8.10/bin/libvips-42.dll
 24924672  vips-dev-8.10/bin/libvips-42.dll
```