### PR TITLE
Add libjxl to 'all' group dependencies for JPEG XL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Same as libvips-web + these extra dependencies:
 | [brotli]        | 1.0.9     | MIT Licence                                                  |
 | [cfitsio]       | 3.49      | BSD-like                                                     |
 | [fftw]          | 3.3.9     | GPLv2                                                        |
-| [highway]       | 82b587d   | Apache-2.0 License                                           |
+| [highway]       | 96ece0b   | Apache-2.0 License                                           |
 | [imagemagick]   | 6.9.12-14 | [ImageMagick License] (GPL-like)                             |
 | [imath]         | 3.0.4     | BSD 3-Clause                                                 |
 | [libjxl]        | 91204ed   | BSD 3-Clause                                                 |

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Same as libvips-web + these extra dependencies:
 | [highway]       | 82b587d   | Apache-2.0 License                                           |
 | [imagemagick]   | 6.9.12-14 | [ImageMagick License] (GPL-like)                             |
 | [imath]         | 3.0.4     | BSD 3-Clause                                                 |
-| [libjxl]        | 37c8685   | BSD 3-Clause                                                 |
+| [libjxl]        | 91204ed   | BSD 3-Clause                                                 |
 | [matio]         | 1.5.21    | BSD 2-Clause                                                 |
 | [nifticlib]     | 2.0.0     | Public domain                                                |
 | [openexr]       | 3.0.4     | BSD 3-Clause                                                 |

--- a/README.md
+++ b/README.md
@@ -91,10 +91,13 @@ Same as libvips-web + these extra dependencies:
 
 | Dependency      | Version   | Used under the terms of                                      |
 |-----------------|-----------|--------------------------------------------------------------|
+| [brotli]        | 1.0.9     | MIT Licence                                                  |
 | [cfitsio]       | 3.49      | BSD-like                                                     |
 | [fftw]          | 3.3.9     | GPLv2                                                        |
+| [highway]       | 82b587d   | Apache-2.0 License                                           |
 | [imagemagick]   | 6.9.12-14 | [ImageMagick License] (GPL-like)                             |
 | [imath]         | 3.0.4     | BSD 3-Clause                                                 |
+| [libjxl]        | 37c8685   | BSD 3-Clause                                                 |
 | [matio]         | 1.5.21    | BSD 2-Clause                                                 |
 | [nifticlib]     | 2.0.0     | Public domain                                                |
 | [openexr]       | 3.0.4     | BSD 3-Clause                                                 |
@@ -103,11 +106,14 @@ Same as libvips-web + these extra dependencies:
 | [poppler]       | 21.06.1   | GPLv2                                                        |
 | [sqlite]        | 3.35.5    | Public domain                                                |
 
+[brotli]: https://github.com/google/brotli
 [cfitsio]: https://heasarc.gsfc.nasa.gov/fitsio/
 [fftw]: https://github.com/FFTW/fftw3
+[highway]: https://github.com/google/highway
 [imagemagick]: https://github.com/ImageMagick/ImageMagick6
 [ImageMagick License]: https://imagemagick.org/script/license.php
 [imath]: https://github.com/AcademySoftwareFoundation/Imath
+[libjxl]: https://github.com/libjxl/libjxl
 [matio]: https://github.com/tbeu/matio
 [nifticlib]: https://nifti.nimh.nih.gov/
 [openexr]: https://github.com/AcademySoftwareFoundation/openexr

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Same as libvips-web + these extra dependencies:
 | [brotli]        | 1.0.9     | MIT Licence                                                  |
 | [cfitsio]       | 3.49      | BSD-like                                                     |
 | [fftw]          | 3.3.9     | GPLv2                                                        |
-| [highway]       | 96ece0b   | Apache-2.0 License                                           |
+| [highway]       | e8ab731   | Apache-2.0 License                                           |
 | [imagemagick]   | 6.9.12-14 | [ImageMagick License] (GPL-like)                             |
 | [imath]         | 3.0.4     | BSD 3-Clause                                                 |
 | [libjxl]        | 91204ed   | BSD 3-Clause                                                 |

--- a/build/brotli.mk
+++ b/build/brotli.mk
@@ -4,6 +4,7 @@ $(PKG)_DESCR    := Brotli compression format
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 1.0.9
 $(PKG)_CHECKSUM := f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46
+$(PKG)_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/brotli-[0-9]*.patch)))
 $(PKG)_GH_CONF  := google/brotli/tags,v
 $(PKG)_DEPS     := cc
 

--- a/build/brotli.mk
+++ b/build/brotli.mk
@@ -1,0 +1,16 @@
+PKG             := brotli
+$(PKG)_WEBSITE  := https://opensource.google.com/projects/brotli
+$(PKG)_DESCR    := Brotli compression format
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.0.9
+$(PKG)_CHECKSUM := f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46
+$(PKG)_GH_CONF  := google/brotli/tags,v
+$(PKG)_DEPS     := cc
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake \
+        -DBROTLI_DISABLE_TESTS=ON \
+        '$(SOURCE_DIR)'
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 $(subst -,/,$(INSTALL_STRIP_LIB))
+endef

--- a/build/highway.mk
+++ b/build/highway.mk
@@ -2,9 +2,9 @@ PKG             := highway
 $(PKG)_WEBSITE  := https://github.com/google/highway
 $(PKG)_DESCR    := Performance-portable, length-agnostic SIMD with runtime dispatch
 $(PKG)_IGNORE   :=
-# https://github.com/google/highway/tarball/82b587d64a3ee85987d86bab8209566f3f81da91
-$(PKG)_VERSION  := 82b587d
-$(PKG)_CHECKSUM := 8760653353b5ceffb4eceee8e06b781265b1a62a6d0661428d2f90fc5bb4f02c
+# https://github.com/google/highway/tarball/96ece0b038318964be63685b6f2100da716dd60d
+$(PKG)_VERSION  := 96ece0b
+$(PKG)_CHECKSUM := 36c7dd6ec3a5f9aadfb25918b8b7ffb475b720d7eec849147ab002d7a4fab3ce
 $(PKG)_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/highway-[0-9]*.patch)))
 $(PKG)_GH_CONF  := google/highway/branches/master
 $(PKG)_DEPS     := cc

--- a/build/highway.mk
+++ b/build/highway.mk
@@ -1,0 +1,18 @@
+PKG             := highway
+$(PKG)_WEBSITE  := https://github.com/google/highway
+$(PKG)_DESCR    := Performance-portable, length-agnostic SIMD with runtime dispatch
+$(PKG)_IGNORE   :=
+# https://github.com/google/highway/tarball/82b587d64a3ee85987d86bab8209566f3f81da91
+$(PKG)_VERSION  := 82b587d
+$(PKG)_CHECKSUM := 8760653353b5ceffb4eceee8e06b781265b1a62a6d0661428d2f90fc5bb4f02c
+$(PKG)_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/highway-[0-9]*.patch)))
+$(PKG)_GH_CONF  := google/highway/branches/master
+$(PKG)_DEPS     := cc
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake \
+        -DBUILD_TESTING=OFF \
+        '$(SOURCE_DIR)'
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 $(subst -,/,$(INSTALL_STRIP_LIB))
+endef

--- a/build/highway.mk
+++ b/build/highway.mk
@@ -2,9 +2,9 @@ PKG             := highway
 $(PKG)_WEBSITE  := https://github.com/google/highway
 $(PKG)_DESCR    := Performance-portable, length-agnostic SIMD with runtime dispatch
 $(PKG)_IGNORE   :=
-# https://github.com/google/highway/tarball/96ece0b038318964be63685b6f2100da716dd60d
-$(PKG)_VERSION  := 96ece0b
-$(PKG)_CHECKSUM := 36c7dd6ec3a5f9aadfb25918b8b7ffb475b720d7eec849147ab002d7a4fab3ce
+# https://github.com/google/highway/tarball/e8ab731e4eff6df5415771518345af85f9bffa0f
+$(PKG)_VERSION  := e8ab731
+$(PKG)_CHECKSUM := f4ff871a60fa7f102e947d0d563f550eff1cc22afc6a6343d2223de85563b31b
 $(PKG)_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/highway-[0-9]*.patch)))
 $(PKG)_GH_CONF  := google/highway/branches/master
 $(PKG)_DEPS     := cc

--- a/build/libjxl.mk
+++ b/build/libjxl.mk
@@ -2,15 +2,16 @@ PKG             := libjxl
 $(PKG)_WEBSITE  := https://github.com/libjxl/libjxl
 $(PKG)_DESCR    := JPEG XL image format reference implementation
 $(PKG)_IGNORE   :=
-# https://github.com/libjxl/libjxl/tarball/37c86853de6f2e75870fcad999c84150da5c67f7
-$(PKG)_VERSION  := 37c8685
-$(PKG)_CHECKSUM := 179d2f46705c8001b399b2e9157e25b5cc3185ed9e22afb793d86c46389b45a0
+# https://github.com/libjxl/libjxl/tarball/91204ed4521a304f983163137283d35c7021de5b
+$(PKG)_VERSION  := 91204ed
+$(PKG)_CHECKSUM := 2d710002e828b066e962b4bed294e2ae7dddff737a6f938f8e83443981032c88
 $(PKG)_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/libjxl-[0-9]*.patch)))
 $(PKG)_GH_CONF  := libjxl/libjxl/branches/main
 $(PKG)_DEPS     := cc brotli highway lcms libjpeg-turbo libpng
 
 define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && $(TARGET)-cmake \
+        -DJPEGXL_STATIC=$(CMAKE_STATIC_BOOL) \
         -DBUILD_TESTING=OFF \
         -DJPEGXL_ENABLE_BENCHMARK=OFF \
         -DJPEGXL_ENABLE_EXAMPLES=OFF \
@@ -18,7 +19,6 @@ define $(PKG)_BUILD
         -DJPEGXL_ENABLE_LODEPNG=OFF \
         -DJPEGXL_ENABLE_OPENEXR=OFF \
         -DJPEGXL_ENABLE_SKCMS=OFF \
-        -DJPEGXL_STATIC=$(CMAKE_STATIC_BOOL) \
         -DJPEGXL_FORCE_SYSTEM_BROTLI=ON \
         -DJPEGXL_FORCE_SYSTEM_HWY=ON \
         -DJPEGXL_FORCE_SYSTEM_LCMS=ON \

--- a/build/libjxl.mk
+++ b/build/libjxl.mk
@@ -1,0 +1,28 @@
+PKG             := libjxl
+$(PKG)_WEBSITE  := https://github.com/libjxl/libjxl
+$(PKG)_DESCR    := JPEG XL image format reference implementation
+$(PKG)_IGNORE   :=
+# https://github.com/libjxl/libjxl/tarball/37c86853de6f2e75870fcad999c84150da5c67f7
+$(PKG)_VERSION  := 37c8685
+$(PKG)_CHECKSUM := 179d2f46705c8001b399b2e9157e25b5cc3185ed9e22afb793d86c46389b45a0
+$(PKG)_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/libjxl-[0-9]*.patch)))
+$(PKG)_GH_CONF  := libjxl/libjxl/branches/main
+$(PKG)_DEPS     := cc highway brotli lcms
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake \
+        -DBUILD_TESTING=OFF \
+        -DJPEGXL_ENABLE_BENCHMARK=OFF \
+        -DJPEGXL_ENABLE_EXAMPLES=OFF \
+        -DJPEGXL_ENABLE_SJPEG=OFF \
+        -DJPEGXL_ENABLE_LODEPNG=OFF \
+        -DJPEGXL_ENABLE_OPENEXR=OFF \
+        -DJPEGXL_ENABLE_SKCMS=OFF \
+        -DJPEGXL_STATIC=$(CMAKE_STATIC_BOOL) \
+        -DJPEGXL_FORCE_SYSTEM_BROTLI=ON \
+        -DJPEGXL_FORCE_SYSTEM_HWY=ON \
+        -DJPEGXL_FORCE_SYSTEM_LCMS=ON \
+        '$(SOURCE_DIR)'
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 $(subst -,/,$(INSTALL_STRIP_LIB))
+endef

--- a/build/libjxl.mk
+++ b/build/libjxl.mk
@@ -7,7 +7,7 @@ $(PKG)_VERSION  := 37c8685
 $(PKG)_CHECKSUM := 179d2f46705c8001b399b2e9157e25b5cc3185ed9e22afb793d86c46389b45a0
 $(PKG)_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/libjxl-[0-9]*.patch)))
 $(PKG)_GH_CONF  := libjxl/libjxl/branches/main
-$(PKG)_DEPS     := cc highway brotli lcms
+$(PKG)_DEPS     := cc brotli highway lcms libjpeg-turbo libpng
 
 define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && $(TARGET)-cmake \

--- a/build/overrides.mk
+++ b/build/overrides.mk
@@ -158,6 +158,7 @@ nasm_URL_2    := https://sources.voidlinux.org/nasm-$(nasm_VERSION)/$(nasm_FILE)
 ## Patches that we override with our own
 
 libjpeg-turbo_PATCHES := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/libjpeg-turbo-[0-9]*.patch)))
+lcms_PATCHES := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/lcms-[0-9]*.patch)))
 
 # zlib will make libzlib.dll, but we want libz.dll so we must
 # patch CMakeLists.txt
@@ -387,6 +388,9 @@ endef
 # build with -DCMS_RELY_ON_WINDOWS_STATIC_MUTEX_INIT to avoid a
 # horrible hack (we don't target pre-Windows XP, so it should be safe)
 define lcms_BUILD
+    # need to regenerate the configure script
+    cd '$(SOURCE_DIR)' && autoreconf -fi
+
     cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure \
         $(MXE_CONFIGURE_OPTS) \
         --with-zlib \
@@ -409,6 +413,7 @@ define imagemagick_BUILD
         --without-gdi32 \
         --without-gvc \
         --without-heic \
+        --without-jxl \
         --without-ltdl \
         --without-lqr \
         --without-lzma \

--- a/build/patches/lcms-2-fixes.patch
+++ b/build/patches/lcms-2-fixes.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kleis Auke Wolthuizen <github@kleisauke.nl>
 Date: Fri, 4 Jun 2021 12:12:02 +0200
-Subject: [PATCH 1/1] Ensure threadsafe alternative of gmtime is used
+Subject: [PATCH 1/2] Ensure threadsafe alternative of gmtime is used
 
 
 diff --git a/configure.ac b/configure.ac
@@ -62,3 +62,97 @@ index 1111111..2222222 100644
  }
  
  cmsContext CMSEXPORT cmsGetProfileContextID(cmsHPROFILE hProfile)
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marti Maria <marti.maria@littlecms.com>
+Date: Wed, 9 Jun 2021 20:45:45 +0200
+Subject: [PATCH 2/2] Provide a thread-safe get time function
+
+Use the context pool mutex in the case of none of the re-entrant alternatives to gmtime() is available
+
+diff --git a/src/cmsio0.c b/src/cmsio0.c
+index 1111111..2222222 100644
+--- a/src/cmsio0.c
++++ b/src/cmsio0.c
+@@ -488,11 +488,6 @@ cmsIOHANDLER* CMSEXPORT cmsGetProfileIOhandler(cmsHPROFILE hProfile)
+ // Creates an empty structure holding all required parameters
+ cmsHPROFILE CMSEXPORT cmsCreateProfilePlaceholder(cmsContext ContextID)
+ {
+-    struct tm *t;
+-#if defined(HAVE_GMTIME_R) || defined(HAVE__GMTIME64_S)
+-    struct tm tm;
+-#endif
+-    time_t now = time(NULL);
+     _cmsICCPROFILE* Icc = (_cmsICCPROFILE*) _cmsMallocZero(ContextID, sizeof(_cmsICCPROFILE));
+     if (Icc == NULL) return NULL;
+ 
+@@ -503,18 +498,10 @@ cmsHPROFILE CMSEXPORT cmsCreateProfilePlaceholder(cmsContext ContextID)
+ 
+     // Set default version
+     Icc ->Version =  0x02100000;
+-
+-#ifdef HAVE_GMTIME_R
+-    t = gmtime_r(&now, &tm);
+-#elif defined(HAVE__GMTIME64_S)
+-    t = _gmtime64_s(&tm, &now) == 0 ? &tm : NULL;
+-#else
+-    t = gmtime(&now);
+-#endif
+-    if (t == NULL) goto Error;
+-
++    
+     // Set creation date/time
+-    memmove(&Icc ->Created, t, sizeof(Icc ->Created));
++    if (!_cmsGetTime(&Icc->Created))
++        goto Error;
+ 
+     // Create a mutex if the user provided proper plugin. NULL otherwise
+     Icc ->UsrMutex = _cmsCreateMutex(ContextID);
+diff --git a/src/cmsplugin.c b/src/cmsplugin.c
+index 1111111..2222222 100644
+--- a/src/cmsplugin.c
++++ b/src/cmsplugin.c
+@@ -989,3 +989,30 @@ void* CMSEXPORT cmsGetContextUserData(cmsContext ContextID)
+ }
+ 
+ 
++// Use context mutex to provide thread-safe time
++cmsBool _cmsGetTime(struct tm* ptr_time)
++{
++    struct tm* t;
++#if defined(HAVE_GMTIME_R) || defined(HAVE__GMTIME64_S)
++    struct tm tm;
++#endif
++
++    time_t now = time(NULL);
++
++#ifdef HAVE_GMTIME_R
++    t = gmtime_r(&now, &tm);
++#elif defined(HAVE__GMTIME64_S)
++    t = _gmtime64_s(&tm, &now) == 0 ? &tm : NULL;
++#else
++    _cmsEnterCriticalSectionPrimitive(&_cmsContextPoolHeadMutex);
++    t = gmtime(&now);
++    _cmsLeaveCriticalSectionPrimitive(&_cmsContextPoolHeadMutex);
++#endif
++
++    if (t == NULL) 
++        return FALSE;
++    else {
++        *ptr_time = *t;
++        return TRUE;
++    }
++}
+diff --git a/src/lcms2_internal.h b/src/lcms2_internal.h
+index 1111111..2222222 100644
+--- a/src/lcms2_internal.h
++++ b/src/lcms2_internal.h
+@@ -1118,5 +1118,8 @@ cmsBool   _cmsAdaptationMatrix(cmsMAT3* r, const cmsMAT3* ConeMatrix, const cmsC
+ cmsBool   _cmsBuildRGB2XYZtransferMatrix(cmsMAT3* r, const cmsCIExyY* WhitePoint, const cmsCIExyYTRIPLE* Primaries);
+ 
+ 
++// thread-safe gettime
++cmsBool _cmsGetTime(struct tm* ptr_time);
++
+ #define _lcms_internal_H
+ #endif

--- a/build/patches/lcms-2-fixes.patch
+++ b/build/patches/lcms-2-fixes.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kleis Auke Wolthuizen <github@kleisauke.nl>
+Date: Fri, 4 Jun 2021 12:12:02 +0200
+Subject: [PATCH 1/1] Ensure threadsafe alternative of gmtime is used
+
+
+diff --git a/configure.ac b/configure.ac
+index 1111111..2222222 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -80,6 +80,9 @@ AX_APPEND_COMPILE_FLAGS(["-fvisibility=hidden"])
+ # Motorola and SPARC CPUs), define `WORDS_BIGENDIAN'.
+ AC_C_BIGENDIAN
+ 
++# Check for functions that some compilers lack (or name differently)
++AC_CHECK_FUNCS([gmtime_r _gmtime64_s])
++
+ # Point to JPEG installed in DIR or disable JPEG with --without-jpeg.
+ AC_ARG_WITH(jpeg,
+             AS_HELP_STRING([--with-jpeg=DIR],[use jpeg installed in DIR]),
+diff --git a/src/cmsio0.c b/src/cmsio0.c
+index 1111111..2222222 100644
+--- a/src/cmsio0.c
++++ b/src/cmsio0.c
+@@ -488,6 +488,10 @@ cmsIOHANDLER* CMSEXPORT cmsGetProfileIOhandler(cmsHPROFILE hProfile)
+ // Creates an empty structure holding all required parameters
+ cmsHPROFILE CMSEXPORT cmsCreateProfilePlaceholder(cmsContext ContextID)
+ {
++    struct tm *t;
++#if defined(HAVE_GMTIME_R) || defined(HAVE__GMTIME64_S)
++    struct tm tm;
++#endif
+     time_t now = time(NULL);
+     _cmsICCPROFILE* Icc = (_cmsICCPROFILE*) _cmsMallocZero(ContextID, sizeof(_cmsICCPROFILE));
+     if (Icc == NULL) return NULL;
+@@ -500,14 +504,27 @@ cmsHPROFILE CMSEXPORT cmsCreateProfilePlaceholder(cmsContext ContextID)
+     // Set default version
+     Icc ->Version =  0x02100000;
+ 
++#ifdef HAVE_GMTIME_R
++    t = gmtime_r(&now, &tm);
++#elif defined(HAVE__GMTIME64_S)
++    t = _gmtime64_s(&tm, &now) == 0 ? &tm : NULL;
++#else
++    t = gmtime(&now);
++#endif
++    if (t == NULL) goto Error;
++
+     // Set creation date/time
+-    memmove(&Icc ->Created, gmtime(&now), sizeof(Icc ->Created));
++    memmove(&Icc ->Created, t, sizeof(Icc ->Created));
+ 
+     // Create a mutex if the user provided proper plugin. NULL otherwise
+     Icc ->UsrMutex = _cmsCreateMutex(ContextID);
+ 
+     // Return the handle
+     return (cmsHPROFILE) Icc;
++
++Error:
++    _cmsFree(ContextID, Icc);
++    return NULL;
+ }
+ 
+ cmsContext CMSEXPORT cmsGetProfileContextID(cmsHPROFILE hProfile)

--- a/build/patches/libjxl-0.4-fixes.patch
+++ b/build/patches/libjxl-0.4-fixes.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kleis Auke Wolthuizen <github@kleisauke.nl>
 Date: Wed, 2 Jun 2021 14:07:04 +0200
-Subject: [PATCH 1/4] Remove LCMS mutex
+Subject: [PATCH 1/5] Remove LCMS mutex
 
 See: https://github.com/libjxl/libjxl/pull/112
 
@@ -70,7 +70,7 @@ index 1111111..2222222 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kleis Auke Wolthuizen <github@kleisauke.nl>
 Date: Tue, 8 Jun 2021 12:40:01 +0200
-Subject: [PATCH 2/4] Allow to build with system-wide installed lcms
+Subject: [PATCH 2/5] Allow to build with system-wide installed lcms
 
 See: https://gitlab.com/wg1/jpeg-xl/-/issues/124
 
@@ -158,7 +158,7 @@ index 1111111..2222222 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kleis Auke Wolthuizen <github@kleisauke.nl>
 Date: Tue, 8 Jun 2021 13:14:53 +0200
-Subject: [PATCH 3/4] Allow to build without LodePNG
+Subject: [PATCH 3/5] Allow to build without LodePNG
 
 Since there's no official release available.
 
@@ -299,7 +299,7 @@ index 1111111..2222222 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kleis Auke Wolthuizen <github@kleisauke.nl>
 Date: Tue, 8 Jun 2021 13:30:49 +0200
-Subject: [PATCH 4/4] Ensure DLLs are installed in the bin directory
+Subject: [PATCH 4/5] Ensure DLLs are installed in the bin directory
 
 
 diff --git a/lib/jxl.cmake b/lib/jxl.cmake
@@ -335,3 +335,129 @@ index 1111111..2222222 100644
  
  endfunction()
  
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kleis Auke Wolthuizen <github@kleisauke.nl>
+Date: Wed, 9 Jun 2021 19:38:33 +0200
+Subject: [PATCH 5/5] tsc_timer: sync with highway
+
+Fixes compilation with llvm-mingw targeting i686.
+
+diff --git a/lib/profiler/tsc_timer.h b/lib/profiler/tsc_timer.h
+index 1111111..2222222 100644
+--- a/lib/profiler/tsc_timer.h
++++ b/lib/profiler/tsc_timer.h
+@@ -10,6 +10,23 @@
+ // ensure exactly the desired regions are measured.
+ 
+ #include <stdint.h>
++#include <time.h>    // clock_gettime
++
++#if defined(_WIN32) || defined(_WIN64)
++#ifndef NOMINMAX
++#define NOMINMAX
++#endif  // NOMINMAX
++#include <windows.h>
++#endif
++
++#if defined(__MACH__)
++#include <mach/mach.h>
++#include <mach/mach_time.h>
++#endif
++
++#if defined(__HAIKU__)
++#include <OS.h>
++#endif
+ 
+ #include <ctime>
+ #include <hwy/base.h>
+@@ -17,9 +34,13 @@
+ 
+ namespace profiler {
+ 
++// Ticks := platform-specific timer values (CPU cycles on x86). Must be
++// unsigned to guarantee wraparound on overflow.
++using Ticks = uint64_t;
++
+ // TicksBefore/After return absolute timestamps and must be placed immediately
+-// before and after the region to measure. The functions are distinct because
+-// they use different fences.
++// before and after the region to measure. We provide separate Before/After
++// functions because they use different fences.
+ //
+ // Background: RDTSC is not 'serializing'; earlier instructions may complete
+ // after it, and/or later instructions may complete before it. 'Fences' ensure
+@@ -55,7 +76,7 @@ namespace profiler {
+ // Using Before+Before leads to higher variance and overhead than After+After.
+ // However, After+After includes an LFENCE in the region measurements, which
+ // adds a delay dependent on earlier loads. The combination of Before+After
+-// is faster than Before+Before and more consistent than Stop+Stop because
++// is faster than Before+Before and more consistent than After+After because
+ // the first LFENCE already delayed subsequent loads before the measured
+ // region. This combination seems not to have been considered in prior work:
+ // http://akaros.cs.berkeley.edu/lxr/akaros/kern/arch/x86/rdtsc_test.c
+@@ -67,19 +88,18 @@ namespace profiler {
+ // by several under/over-count errata, so we use the TSC instead.
+ 
+ // Returns a 64-bit timestamp in unit of 'ticks'; to convert to seconds,
+-// divide by InvariantTicksPerSecond. Although 32-bit ticks are faster to read,
+-// they overflow too quickly to measure long regions.
+-static HWY_INLINE HWY_MAYBE_UNUSED uint64_t TicksBefore() {
+-  uint64_t t;
++// divide by InvariantTicksPerSecond.
++static HWY_INLINE HWY_MAYBE_UNUSED Ticks TicksBefore() {
++  Ticks t;
+ #if HWY_ARCH_PPC
+   asm volatile("mfspr %0, %1" : "=r"(t) : "i"(268));
+-#elif HWY_ARCH_X86_64 && HWY_COMPILER_MSVC
++#elif HWY_ARCH_X86 && HWY_COMPILER_MSVC
+   hwy::LoadFence();
+   HWY_FENCE;
+   t = __rdtsc();
+   hwy::LoadFence();
+   HWY_FENCE;
+-#elif HWY_ARCH_X86_64 && (HWY_COMPILER_CLANG || HWY_COMPILER_GCC)
++#elif HWY_ARCH_X86_64
+   asm volatile(
+       "lfence\n\t"
+       "rdtsc\n\t"
+@@ -91,7 +111,17 @@ static HWY_INLINE HWY_MAYBE_UNUSED uint64_t TicksBefore() {
+       // "memory" avoids reordering. rdx = TSC >> 32.
+       // "cc" = flags modified by SHL.
+       : "rdx", "memory", "cc");
+-#else
++#elif HWY_ARCH_RVV
++  asm volatile("rdcycle %0" : "=r"(t));
++#elif defined(_WIN32) || defined(_WIN64)
++  LARGE_INTEGER counter;
++  (void)QueryPerformanceCounter(&counter);
++  t = counter.QuadPart;
++#elif defined(__MACH__)
++  t = mach_absolute_time();
++#elif defined(__HAIKU__)
++  t = system_time_nsecs();  // since boot
++#else  // POSIX
+   // Fall back to OS - unsure how to reliably query cntvct_el0 frequency.
+   timespec ts;
+   clock_gettime(CLOCK_MONOTONIC, &ts);
+@@ -100,15 +130,17 @@ static HWY_INLINE HWY_MAYBE_UNUSED uint64_t TicksBefore() {
+   return t;
+ }
+ 
+-static HWY_INLINE HWY_MAYBE_UNUSED uint64_t TicksAfter() {
+-  uint64_t t;
+-#if HWY_ARCH_X86_64 && HWY_COMPILER_MSVC
++static HWY_INLINE HWY_MAYBE_UNUSED Ticks TicksAfter() {
++  Ticks t;
++#if HWY_ARCH_PPC
++  asm volatile("mfspr %0, %1" : "=r"(t) : "i"(268));
++#elif HWY_ARCH_X86 && HWY_COMPILER_MSVC
+   HWY_FENCE;
+   unsigned aux;
+   t = __rdtscp(&aux);
+   hwy::LoadFence();
+   HWY_FENCE;
+-#elif HWY_ARCH_X86_64 && (HWY_COMPILER_CLANG || HWY_COMPILER_GCC)
++#elif HWY_ARCH_X86_64
+   // Use inline asm because __rdtscp generates code to store TSC_AUX (ecx).
+   asm volatile(
+       "rdtscp\n\t"

--- a/build/patches/libjxl-0.4-fixes.patch
+++ b/build/patches/libjxl-0.4-fixes.patch
@@ -1,0 +1,369 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kleis Auke Wolthuizen <github@kleisauke.nl>
+Date: Wed, 2 Jun 2021 14:07:04 +0200
+Subject: [PATCH 1/5] Remove LCMS mutex
+
+See: https://github.com/libjxl/libjxl/pull/112
+
+diff --git a/lib/jxl/enc_color_management.cc b/lib/jxl/enc_color_management.cc
+index 1111111..2222222 100644
+--- a/lib/jxl/enc_color_management.cc
++++ b/lib/jxl/enc_color_management.cc
+@@ -20,7 +20,6 @@
+ #include <array>
+ #include <atomic>
+ #include <memory>
+-#include <mutex>
+ #include <string>
+ #include <utility>
+ 
+@@ -236,14 +235,6 @@ namespace {
+ // Define to 1 on OS X as a workaround for older LCMS lacking MD5.
+ #define JXL_CMS_OLD_VERSION 0
+ 
+-// cms functions (even *THR) are not thread-safe, except cmsDoTransform.
+-// To ensure all functions are covered without frequent lock-taking nor risk of
+-// recursive lock, we lock in the top-level APIs.
+-static std::mutex& LcmsMutex() {
+-  static std::mutex m;
+-  return m;
+-}
+-
+ #if JPEGXL_ENABLE_SKCMS
+ 
+ JXL_MUST_USE_RESULT CIExy CIExyFromXYZ(const float XYZ[3]) {
+@@ -638,9 +629,6 @@ cmsContext GetContext() {
+ 
+ }  // namespace
+ 
+-// All functions that call lcms directly (except ColorSpaceTransform::Run) must
+-// lock LcmsMutex().
+-
+ Status ColorEncoding::SetFieldsFromICC() {
+   // In case parsing fails, mark the ColorEncoding as invalid.
+   SetColorSpace(ColorSpace::kUnknown);
+@@ -679,7 +667,6 @@ Status ColorEncoding::SetFieldsFromICC() {
+   rendering_intent = static_cast<RenderingIntent>(rendering_intent32);
+ #else   // JPEGXL_ENABLE_SKCMS
+ 
+-  std::lock_guard<std::mutex> guard(LcmsMutex());
+   const cmsContext context = GetContext();
+ 
+   Profile profile;
+@@ -732,7 +719,6 @@ void ColorEncoding::DecideIfWantICC() {
+ 
+ ColorSpaceTransform::~ColorSpaceTransform() {
+ #if !JPEGXL_ENABLE_SKCMS
+-  std::lock_guard<std::mutex> guard(LcmsMutex());
+   TransformDeleter()(lcms_transform_);
+ #endif
+ }
+@@ -748,7 +734,6 @@ Status ColorSpaceTransform::Init(const ColorEncoding& c_src,
+                                  const ColorEncoding& c_dst,
+                                  float intensity_target, size_t xsize,
+                                  const size_t num_threads) {
+-  std::lock_guard<std::mutex> guard(LcmsMutex());
+ #if JXL_CMS_VERBOSE
+   printf("%s -> %s\n", Description(c_src).c_str(), Description(c_dst).c_str());
+ #endif
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kleis Auke Wolthuizen <github@kleisauke.nl>
+Date: Fri, 4 Jun 2021 12:46:13 +0200
+Subject: [PATCH 2/5] Use a threadsafe alternative of gmtime in LCMS
+
+
+diff --git a/third_party/lcms2.cmake b/third_party/lcms2.cmake
+index 1111111..2222222 100644
+--- a/third_party/lcms2.cmake
++++ b/third_party/lcms2.cmake
+@@ -60,4 +60,20 @@ target_compile_definitions(lcms2
+ target_compile_definitions(lcms2
+   PUBLIC "-DCMS_NO_REGISTER_KEYWORD=1")
+ 
++# Ensure that a thread safe alternative of gmtime is used in LCMS
++include(CheckFunctionExists)
++if (WIN32)
++  check_function_exists(_gmtime64_s HAVE__GMTIME64_S)
++else()
++  check_function_exists(gmtime_r HAVE_GMTIME_R)
++endif()
++if (HAVE__GMTIME64_S)
++  target_compile_definitions(lcms2
++    PUBLIC "-DHAVE__GMTIME64_S=1")
++endif()
++if (HAVE_GMTIME_R)
++  target_compile_definitions(lcms2
++    PUBLIC "-DHAVE_GMTIME_R=1")
++endif()
++
+ set_property(TARGET lcms2 PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kleis Auke Wolthuizen <github@kleisauke.nl>
+Date: Tue, 8 Jun 2021 12:40:01 +0200
+Subject: [PATCH 3/5] Allow to build with system-wide installed lcms
+
+See: https://gitlab.com/wg1/jpeg-xl/-/issues/124
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1111111..2222222 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -118,6 +118,8 @@ set(JPEGXL_FORCE_SYSTEM_BROTLI false CACHE BOOL
+     "Force using system installed brotli instead of third_party/brotli source.")
+ set(JPEGXL_FORCE_SYSTEM_HWY false CACHE BOOL
+     "Force using system installed highway (libhwy-dev) instead of third_party/highway source.")
++set(JPEGXL_FORCE_SYSTEM_LCMS false CACHE BOOL
++    "Force using system installed lcms instead of third_party/lcms source.")
+ 
+ # Check minimum compiler versions. Older compilers are not supported and fail
+ # with hard to understand errors.
+diff --git a/deps.sh b/deps.sh
+index 1111111..2222222 100755
+--- a/deps.sh
++++ b/deps.sh
+@@ -16,6 +16,7 @@ MYDIR=$(dirname $(realpath "$0"))
+ THIRD_PARTY_HIGHWAY="82b587d64a3ee85987d86bab8209566f3f81da91"
+ THIRD_PARTY_LODEPNG="48e5364ef48ec2408f44c727657ac1b6703185f8"
+ THIRD_PARTY_SKCMS="64374756e03700d649f897dbd98c95e78c30c7da"
++THIRD_PARTY_LCMS="17eb080324a9f16e0e7ab37bbcda7ae42b946294"
+ THIRD_PARTY_SJPEG="868ab558fad70fcbe8863ba4e85179eeb81cc840"
+ 
+ # Download the target revision from GitHub.
+@@ -74,6 +75,7 @@ EOF
+   download_github third_party/sjpeg webmproject/sjpeg
+   download_github third_party/skcms \
+     "https://skia.googlesource.com/skcms/+archive/"
++  download_github third_party/lcms mm2/Little-CMS
+   echo "Done."
+ }
+ 
+diff --git a/third_party/CMakeLists.txt b/third_party/CMakeLists.txt
+index 1111111..2222222 100644
+--- a/third_party/CMakeLists.txt
++++ b/third_party/CMakeLists.txt
+@@ -202,12 +202,37 @@ if (JPEGXL_ENABLE_SKCMS)
+                  ${PROJECT_BINARY_DIR}/LICENSE.skcms COPYONLY)
+ endif ()
+ if (JPEGXL_ENABLE_VIEWERS OR NOT JPEGXL_ENABLE_SKCMS)
+-  if( NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/lcms/.git" )
+-    message(SEND_ERROR "Please run git submodule update --init")
++  if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/lcms/include/lcms2.h" OR
++      JPEGXL_FORCE_SYSTEM_LCMS)
++    pkg_check_modules(lcms2 lcms2>=2.11)
++    if (lcms2_FOUND)
++      add_library(lcms2 INTERFACE IMPORTED GLOBAL)
++      if(${CMAKE_VERSION} VERSION_LESS "3.13.5")
++        set_property(TARGET lcms2 PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${lcms2_INCLUDE_DIR})
++        target_link_libraries(lcms2 INTERFACE ${lcms2_LDFLAGS})
++        set_property(TARGET lcms2 PROPERTY INTERFACE_COMPILE_OPTIONS ${lcms2_CFLAGS_OTHER})
++      else()
++        target_include_directories(lcms2
++            INTERFACE ${lcms2_INCLUDE_DIRS})
++        target_link_libraries(lcms2
++            INTERFACE ${lcms2_LINK_LIBRARIES})
++        target_link_options(lcms2
++            INTERFACE ${lcms2_LDFLAGS_OTHER})
++        target_compile_options(lcms2
++            INTERFACE ${lcms2_CFLAGS_OTHER})
++      endif()
++    else()
++      message(FATAL_ERROR
++              "lcms2 not found, install liblcms2-dev or download lcms2 source code to"
++              " third_party/lcms from https://github.com/mm2/little-cms. You can use"
++              " ${PROJECT_SOURCE_DIR}/deps.sh to download this dependency.")
++    endif()
++  else()
++    # Compile lcms from sources.
++    include(lcms2.cmake)
++    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/lcms/COPYING"
++                   ${PROJECT_BINARY_DIR}/LICENSE.lcms COPYONLY)
+   endif()
+-  include(lcms2.cmake)
+-  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/lcms/COPYING"
+-                 ${PROJECT_BINARY_DIR}/LICENSE.lcms COPYONLY)
+ endif()
+ 
+ # sjpeg
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kleis Auke Wolthuizen <github@kleisauke.nl>
+Date: Tue, 8 Jun 2021 13:14:53 +0200
+Subject: [PATCH 4/5] Allow to build without LodePNG
+
+Since there's no official release available.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1111111..2222222 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -83,6 +83,8 @@ set(JPEGXL_ENABLE_EXAMPLES true CACHE BOOL
+     "Build JPEGXL library usage examples.")
+ set(JPEGXL_ENABLE_SJPEG true CACHE BOOL
+     "Build JPEGXL with support for encoding with sjpeg.")
++set(JPEGXL_ENABLE_LODEPNG true CACHE BOOL
++    "Build JPEGXL with support for LodePNG.")
+ set(JPEGXL_ENABLE_OPENEXR true CACHE BOOL
+     "Build JPEGXL with support for OpenEXR if available.")
+ set(JPEGXL_ENABLE_SKCMS true CACHE BOOL
+diff --git a/lib/extras/codec.cc b/lib/extras/codec.cc
+index 1111111..2222222 100644
+--- a/lib/extras/codec.cc
++++ b/lib/extras/codec.cc
+@@ -6,6 +6,9 @@
+ #include "lib/extras/codec.h"
+ 
+ #include "lib/jxl/base/file_io.h"
++#if JPEGXL_ENABLE_LODEPNG
++#include "lib/extras/codec_png.h"
++#endif
+ #if JPEGXL_ENABLE_APNG
+ #include "lib/extras/codec_apng.h"
+ #endif
+@@ -17,7 +20,6 @@
+ #endif
+ #include "lib/extras/codec_jpg.h"
+ #include "lib/extras/codec_pgx.h"
+-#include "lib/extras/codec_png.h"
+ #include "lib/extras/codec_pnm.h"
+ #include "lib/extras/codec_psd.h"
+ #include "lib/jxl/image_bundle.h"
+@@ -91,19 +93,21 @@ Status SetFromBytes(const Span<const uint8_t> bytes, CodecInOut* io,
+   io->metadata.m.bit_depth.bits_per_sample = 0;  // (For is-set check below)
+ 
+   Codec codec;
+-  if (DecodeImagePNG(bytes, pool, io)) {
++  if (DecodeImagePGX(bytes, pool, io)) {
++    codec = Codec::kPGX;
++  } else if (DecodeImagePNM(bytes, pool, io)) {
++    codec = Codec::kPNM;
++  }
++#if JPEGXL_ENABLE_LODEPNG
++  else if (DecodeImagePNG(bytes, pool, io)) {
+     codec = Codec::kPNG;
+   }
++#endif
+ #if JPEGXL_ENABLE_APNG
+   else if (DecodeImageAPNG(bytes, pool, io)) {
+     codec = Codec::kPNG;
+   }
+ #endif
+-  else if (DecodeImagePGX(bytes, pool, io)) {
+-    codec = Codec::kPGX;
+-  } else if (DecodeImagePNM(bytes, pool, io)) {
+-    codec = Codec::kPNM;
+-  }
+ #if JPEGXL_ENABLE_GIF
+   else if (DecodeImageGIF(bytes, pool, io)) {
+     codec = Codec::kGIF;
+@@ -152,7 +156,11 @@ Status Encode(const CodecInOut& io, const Codec codec,
+ 
+   switch (codec) {
+     case Codec::kPNG:
++#if JPEGXL_ENABLE_LODEPNG
+       return EncodeImagePNG(&io, c_desired, bits_per_sample, pool, bytes);
++#else
++      return JXL_FAILURE("JPEG XL was built without PNG support");
++#endif
+     case Codec::kJPG:
+ #if JPEGXL_ENABLE_JPEG
+       return EncodeImageJPG(
+diff --git a/lib/jxl_extras.cmake b/lib/jxl_extras.cmake
+index 1111111..2222222 100644
+--- a/lib/jxl_extras.cmake
++++ b/lib/jxl_extras.cmake
+@@ -13,8 +13,6 @@ set(JPEGXL_EXTRAS_SOURCES
+   extras/codec_jpg.h
+   extras/codec_pgx.cc
+   extras/codec_pgx.h
+-  extras/codec_png.cc
+-  extras/codec_png.h
+   extras/codec_pnm.cc
+   extras/codec_pnm.h
+   extras/codec_psd.cc
+@@ -32,9 +30,17 @@ set_property(TARGET jxl_extras-static PROPERTY POSITION_INDEPENDENT_CODE ON)
+ target_include_directories(jxl_extras-static PUBLIC "${PROJECT_SOURCE_DIR}")
+ target_link_libraries(jxl_extras-static PUBLIC
+   jxl-static
+-  lodepng
+ )
+ 
++if (JPEGXL_ENABLE_LODEPNG)
++  target_sources(jxl_extras-static PRIVATE
++    extras/codec_png.cc
++    extras/codec_png.h
++  )
++  target_compile_definitions(jxl_extras-static PUBLIC -DJPEGXL_ENABLE_LODEPNG=1)
++  target_link_libraries(jxl_extras-static PUBLIC lodepng)
++endif()
++
+ find_package(GIF 5)
+ if(GIF_FOUND)
+   target_sources(jxl_extras-static PRIVATE
+diff --git a/third_party/CMakeLists.txt b/third_party/CMakeLists.txt
+index 1111111..2222222 100644
+--- a/third_party/CMakeLists.txt
++++ b/third_party/CMakeLists.txt
+@@ -114,13 +114,15 @@ else()
+ endif()
+ 
+ # lodepng
+-if( NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/lodepng/lodepng.h" )
+-  message(FATAL_ERROR "Please run ${PROJECT_SOURCE_DIR}/deps.sh to fetch the "
+-          "build dependencies.")
++if (JPEGXL_ENABLE_LODEPNG)
++  if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/lodepng/lodepng.h")
++    message(FATAL_ERROR "Please run ${PROJECT_SOURCE_DIR}/deps.sh to fetch the "
++            "build dependencies.")
++  endif()
++  include(lodepng.cmake)
++  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/lodepng/LICENSE"
++                 ${PROJECT_BINARY_DIR}/LICENSE.lodepng COPYONLY)
+ endif()
+-include(lodepng.cmake)
+-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/lodepng/LICENSE"
+-               ${PROJECT_BINARY_DIR}/LICENSE.lodepng COPYONLY)
+ 
+ # brotli
+ if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/brotli/c/include/brotli/decode.h" OR
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kleis Auke Wolthuizen <github@kleisauke.nl>
+Date: Tue, 8 Jun 2021 13:30:49 +0200
+Subject: [PATCH 5/5] Ensure DLLs are installed in the bin directory
+
+
+diff --git a/lib/jxl.cmake b/lib/jxl.cmake
+index 1111111..2222222 100644
+--- a/lib/jxl.cmake
++++ b/lib/jxl.cmake
+@@ -534,7 +534,10 @@ endforeach()
+ # contains symbols also in libjxl which would conflict if programs try to use
+ # both.
+ install(TARGETS jxl
+-  DESTINATION ${CMAKE_INSTALL_LIBDIR})
++  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++)
+ else()
+ add_library(jxl ALIAS jxl-static)
+ add_library(jxl_dec ALIAS jxl_dec-static)
+diff --git a/lib/jxl_threads.cmake b/lib/jxl_threads.cmake
+index 1111111..2222222 100644
+--- a/lib/jxl_threads.cmake
++++ b/lib/jxl_threads.cmake
+@@ -43,7 +43,11 @@ set_target_properties(${_target} PROPERTIES
+ if (NOT WIN32)
+   set_target_properties(${_target} PROPERTIES OUTPUT_NAME "jxl_threads")
+ endif()
+-install(TARGETS ${_target} DESTINATION ${CMAKE_INSTALL_LIBDIR})
++install(TARGETS ${_target}
++  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++)
+ 
+ endfunction()
+ 

--- a/build/patches/libjxl-0.4-fixes.patch
+++ b/build/patches/libjxl-0.4-fixes.patch
@@ -346,17 +346,23 @@ diff --git a/lib/profiler/tsc_timer.h b/lib/profiler/tsc_timer.h
 index 1111111..2222222 100644
 --- a/lib/profiler/tsc_timer.h
 +++ b/lib/profiler/tsc_timer.h
-@@ -10,6 +10,23 @@
+@@ -10,6 +10,29 @@
  // ensure exactly the desired regions are measured.
  
  #include <stdint.h>
 +#include <time.h>    // clock_gettime
 +
 +#if defined(_WIN32) || defined(_WIN64)
++#ifndef WIN32_LEAN_AND_MEAN
++#define WIN32_LEAN_AND_MEAN
++#endif  // WIN32_LEAN_AND_MEAN
 +#ifndef NOMINMAX
 +#define NOMINMAX
 +#endif  // NOMINMAX
 +#include <windows.h>
++// Undef macros to avoid collisions
++#undef LoadFence
++#undef StoreFence
 +#endif
 +
 +#if defined(__MACH__)
@@ -370,7 +376,7 @@ index 1111111..2222222 100644
  
  #include <ctime>
  #include <hwy/base.h>
-@@ -17,9 +34,13 @@
+@@ -17,9 +40,13 @@
  
  namespace profiler {
  
@@ -386,7 +392,7 @@ index 1111111..2222222 100644
  //
  // Background: RDTSC is not 'serializing'; earlier instructions may complete
  // after it, and/or later instructions may complete before it. 'Fences' ensure
-@@ -55,7 +76,7 @@ namespace profiler {
+@@ -55,7 +82,7 @@ namespace profiler {
  // Using Before+Before leads to higher variance and overhead than After+After.
  // However, After+After includes an LFENCE in the region measurements, which
  // adds a delay dependent on earlier loads. The combination of Before+After
@@ -395,7 +401,7 @@ index 1111111..2222222 100644
  // the first LFENCE already delayed subsequent loads before the measured
  // region. This combination seems not to have been considered in prior work:
  // http://akaros.cs.berkeley.edu/lxr/akaros/kern/arch/x86/rdtsc_test.c
-@@ -67,19 +88,18 @@ namespace profiler {
+@@ -67,19 +94,18 @@ namespace profiler {
  // by several under/over-count errata, so we use the TSC instead.
  
  // Returns a 64-bit timestamp in unit of 'ticks'; to convert to seconds,
@@ -420,7 +426,7 @@ index 1111111..2222222 100644
    asm volatile(
        "lfence\n\t"
        "rdtsc\n\t"
-@@ -91,7 +111,17 @@ static HWY_INLINE HWY_MAYBE_UNUSED uint64_t TicksBefore() {
+@@ -91,7 +117,17 @@ static HWY_INLINE HWY_MAYBE_UNUSED uint64_t TicksBefore() {
        // "memory" avoids reordering. rdx = TSC >> 32.
        // "cc" = flags modified by SHL.
        : "rdx", "memory", "cc");
@@ -439,7 +445,7 @@ index 1111111..2222222 100644
    // Fall back to OS - unsure how to reliably query cntvct_el0 frequency.
    timespec ts;
    clock_gettime(CLOCK_MONOTONIC, &ts);
-@@ -100,15 +130,17 @@ static HWY_INLINE HWY_MAYBE_UNUSED uint64_t TicksBefore() {
+@@ -100,15 +136,17 @@ static HWY_INLINE HWY_MAYBE_UNUSED uint64_t TicksBefore() {
    return t;
  }
  

--- a/build/patches/libjxl-0.4-fixes.patch
+++ b/build/patches/libjxl-0.4-fixes.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kleis Auke Wolthuizen <github@kleisauke.nl>
 Date: Wed, 2 Jun 2021 14:07:04 +0200
-Subject: [PATCH 1/5] Remove LCMS mutex
+Subject: [PATCH 1/4] Remove LCMS mutex
 
 See: https://github.com/libjxl/libjxl/pull/112
 
@@ -69,40 +69,8 @@ index 1111111..2222222 100644
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kleis Auke Wolthuizen <github@kleisauke.nl>
-Date: Fri, 4 Jun 2021 12:46:13 +0200
-Subject: [PATCH 2/5] Use a threadsafe alternative of gmtime in LCMS
-
-
-diff --git a/third_party/lcms2.cmake b/third_party/lcms2.cmake
-index 1111111..2222222 100644
---- a/third_party/lcms2.cmake
-+++ b/third_party/lcms2.cmake
-@@ -60,4 +60,20 @@ target_compile_definitions(lcms2
- target_compile_definitions(lcms2
-   PUBLIC "-DCMS_NO_REGISTER_KEYWORD=1")
- 
-+# Ensure that a thread safe alternative of gmtime is used in LCMS
-+include(CheckFunctionExists)
-+if (WIN32)
-+  check_function_exists(_gmtime64_s HAVE__GMTIME64_S)
-+else()
-+  check_function_exists(gmtime_r HAVE_GMTIME_R)
-+endif()
-+if (HAVE__GMTIME64_S)
-+  target_compile_definitions(lcms2
-+    PUBLIC "-DHAVE__GMTIME64_S=1")
-+endif()
-+if (HAVE_GMTIME_R)
-+  target_compile_definitions(lcms2
-+    PUBLIC "-DHAVE_GMTIME_R=1")
-+endif()
-+
- set_property(TARGET lcms2 PROPERTY POSITION_INDEPENDENT_CODE ON)
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Kleis Auke Wolthuizen <github@kleisauke.nl>
 Date: Tue, 8 Jun 2021 12:40:01 +0200
-Subject: [PATCH 3/5] Allow to build with system-wide installed lcms
+Subject: [PATCH 2/4] Allow to build with system-wide installed lcms
 
 See: https://gitlab.com/wg1/jpeg-xl/-/issues/124
 
@@ -190,7 +158,7 @@ index 1111111..2222222 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kleis Auke Wolthuizen <github@kleisauke.nl>
 Date: Tue, 8 Jun 2021 13:14:53 +0200
-Subject: [PATCH 4/5] Allow to build without LodePNG
+Subject: [PATCH 3/4] Allow to build without LodePNG
 
 Since there's no official release available.
 
@@ -331,7 +299,7 @@ index 1111111..2222222 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kleis Auke Wolthuizen <github@kleisauke.nl>
 Date: Tue, 8 Jun 2021 13:30:49 +0200
-Subject: [PATCH 5/5] Ensure DLLs are installed in the bin directory
+Subject: [PATCH 4/4] Ensure DLLs are installed in the bin directory
 
 
 diff --git a/lib/jxl.cmake b/lib/jxl.cmake

--- a/build/plugins/mozjpeg/overrides.mk
+++ b/build/plugins/mozjpeg/overrides.mk
@@ -5,6 +5,7 @@ IS_MOZJPEG := $(true)
 # Override sub-dependencies
 gdk-pixbuf_DEPS  := $(subst libjpeg-turbo,mozjpeg,$(gdk-pixbuf_DEPS))
 imagemagick_DEPS := $(subst libjpeg-turbo,mozjpeg,$(imagemagick_DEPS))
+libjxl_DEPS      := $(subst libjpeg-turbo,mozjpeg,$(libjxl_DEPS))
 openslide_DEPS   := $(subst libjpeg-turbo,mozjpeg,$(openslide_DEPS))
 poppler_DEPS     := $(subst libjpeg-turbo,mozjpeg,$(poppler_DEPS))
 tiff_DEPS        := $(subst libjpeg-turbo,mozjpeg,$(tiff_DEPS))

--- a/build/vips-all.mk
+++ b/build/vips-all.mk
@@ -11,7 +11,7 @@ $(PKG)_FILE     := vips-$($(PKG)_VERSION)-rc1.tar.gz
 $(PKG)_DEPS     := cc libwebp librsvg glib pango libgsf \
                    libjpeg-turbo tiff lcms libexif libheif libpng \
                    libspng libimagequant orc imagemagick matio openexr \
-                   cfitsio nifticlib poppler fftw openslide
+                   cfitsio nifticlib poppler fftw openslide libjxl
 
 define $(PKG)_PRE_CONFIGURE
     # Copy some files to the packaging directory
@@ -20,6 +20,7 @@ define $(PKG)_PRE_CONFIGURE
 
     (printf '{\n'; \
      printf '  "aom": "$(aom_VERSION)",\n'; \
+     printf '  "brotli": "$(brotli_VERSION)",\n'; \
      printf '  "cairo": "$(cairo_VERSION)",\n'; \
      printf '  "cfitsio": "$(cfitsio_VERSION)",\n'; \
      $(if $(IS_HEVC),printf '  "de265": "$(libde265_VERSION)"$(comma)\n';) \
@@ -35,9 +36,11 @@ define $(PKG)_PRE_CONFIGURE
      printf '  "gsf": "$(libgsf_VERSION)",\n'; \
      printf '  "harfbuzz": "$(harfbuzz_VERSION)",\n'; \
      printf '  "heif": "$(libheif_VERSION)",\n'; \
+     printf '  "highway": "$(highway_VERSION)",\n'; \
      printf '  "imagemagick": "$(imagemagick_VERSION)",\n'; \
      printf '  "imagequant": "$(libimagequant_VERSION)",\n'; \
      $(if $(IS_MOZJPEG),,printf '  "jpeg": "$(libjpeg-turbo_VERSION)"$(comma)\n';) \
+     printf '  "jxl": "$(libjxl_VERSION)",\n'; \
      printf '  "lcms": "$(lcms_VERSION)",\n'; \
      printf '  "matio": "$(matio_VERSION)",\n'; \
      $(if $(IS_MOZJPEG),printf '  "mozjpeg": "$(mozjpeg_VERSION)"$(comma)\n';) \
@@ -71,7 +74,6 @@ define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure \
         $(MXE_CONFIGURE_OPTS) \
         --enable-debug=no \
-        --without-libjxl \
         --without-pdfium \
         --disable-introspection \
         --disable-deprecated \


### PR DESCRIPTION
To allow users to experiment with the JPEG XL integration of libvips v8.11.