### PR TITLE
glib: remove deprecated/unused GRegex via patch

### DIFF
--- a/build/patches/glib-2-without-gregex.patch
+++ b/build/patches/glib-2-without-gregex.patch
@@ -1,0 +1,115 @@
+diff --git a/gio/gsettingsschema.c b/gio/gsettingsschema.c
+index ec0caf655..c6799a2ba 100644
+--- a/gio/gsettingsschema.c
++++ b/gio/gsettingsschema.c
+@@ -551,58 +551,7 @@ start_element (GMarkupParseContext  *context,
+ static gchar *
+ normalise_whitespace (const gchar *orig)
+ {
+-  /* We normalise by the same rules as in intltool:
+-   *
+-   *   sub cleanup {
+-   *       s/^\s+//;
+-   *       s/\s+$//;
+-   *       s/\s+/ /g;
+-   *       return $_;
+-   *   }
+-   *
+-   *   $message = join "\n\n", map &cleanup, split/\n\s*\n+/, $message;
+-   *
+-   * Where \s is an ascii space character.
+-   *
+-   * We aim for ease of implementation over efficiency -- this code is
+-   * not run in normal applications.
+-   */
+-  static GRegex *cleanup[3];
+-  static GRegex *splitter;
+-  gchar **lines;
+-  gchar *result;
+-  gint i;
+-
+-  if (g_once_init_enter (&splitter))
+-    {
+-      GRegex *s;
+-
+-      cleanup[0] = g_regex_new ("^\\s+", 0, 0, 0);
+-      cleanup[1] = g_regex_new ("\\s+$", 0, 0, 0);
+-      cleanup[2] = g_regex_new ("\\s+", 0, 0, 0);
+-      s = g_regex_new ("\\n\\s*\\n+", 0, 0, 0);
+-
+-      g_once_init_leave (&splitter, s);
+-    }
+-
+-  lines = g_regex_split (splitter, orig, 0);
+-  for (i = 0; lines[i]; i++)
+-    {
+-      gchar *a, *b, *c;
+-
+-      a = g_regex_replace_literal (cleanup[0], lines[i], -1, 0, "", 0, 0);
+-      b = g_regex_replace_literal (cleanup[1], a, -1, 0, "", 0, 0);
+-      c = g_regex_replace_literal (cleanup[2], b, -1, 0, " ", 0, 0);
+-      g_free (lines[i]);
+-      g_free (a);
+-      g_free (b);
+-      lines[i] = c;
+-    }
+-
+-  result = g_strjoinv ("\n\n", lines);
+-  g_strfreev (lines);
+-
+-  return result;
++  return orig;
+ }
+ 
+ static void
+diff --git a/glib/glib-autocleanups.h b/glib/glib-autocleanups.h
+index 6457eaff8..f72031fb1 100644
+--- a/glib/glib-autocleanups.h
++++ b/glib/glib-autocleanups.h
+@@ -71,8 +71,6 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(GPatternSpec, g_pattern_spec_free)
+ G_DEFINE_AUTOPTR_CLEANUP_FUNC(GQueue, g_queue_free)
+ G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GQueue, g_queue_clear)
+ G_DEFINE_AUTOPTR_CLEANUP_FUNC(GRand, g_rand_free)
+-G_DEFINE_AUTOPTR_CLEANUP_FUNC(GRegex, g_regex_unref)
+-G_DEFINE_AUTOPTR_CLEANUP_FUNC(GMatchInfo, g_match_info_unref)
+ G_DEFINE_AUTOPTR_CLEANUP_FUNC(GScanner, g_scanner_destroy)
+ G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSequence, g_sequence_free)
+ G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSList, g_slist_free)
+diff --git a/glib/glib.h b/glib/glib.h
+index e72c09da5..d639e645e 100644
+--- a/glib/glib.h
++++ b/glib/glib.h
+@@ -72,7 +72,6 @@
+ #include <glib/grcbox.h>
+ #include <glib/grefcount.h>
+ #include <glib/grefstring.h>
+-#include <glib/gregex.h>
+ #include <glib/gscanner.h>
+ #include <glib/gsequence.h>
+ #include <glib/gshell.h>
+diff --git a/glib/meson.build b/glib/meson.build
+index 93600b29e..3ebcbeb02 100644
+--- a/glib/meson.build
++++ b/glib/meson.build
+@@ -187,7 +187,6 @@ glib_sub_headers = files(
+   'grcbox.h',
+   'grefcount.h',
+   'grefstring.h',
+-  'gregex.h',
+   'gscanner.h',
+   'gsequence.h',
+   'gshell.h',
+diff --git a/gobject/gboxed.c b/gobject/gboxed.c
+index ae48df566..9f1ca04c8 100644
+--- a/gobject/gboxed.c
++++ b/gobject/gboxed.c
+@@ -147,9 +147,6 @@ G_DEFINE_BOXED_TYPE (GByteArray, g_byte_array, g_byte_array_ref, g_byte_array_un
+ G_DEFINE_BOXED_TYPE (GBytes, g_bytes, g_bytes_ref, g_bytes_unref)
+ G_DEFINE_BOXED_TYPE (GTree, g_tree, g_tree_ref, g_tree_unref)
+ 
+-G_DEFINE_BOXED_TYPE (GRegex, g_regex, g_regex_ref, g_regex_unref)
+-G_DEFINE_BOXED_TYPE (GMatchInfo, g_match_info, g_match_info_ref, g_match_info_unref)
+-
+ #define g_variant_type_get_type g_variant_type_get_gtype
+ G_DEFINE_BOXED_TYPE (GVariantType, g_variant_type, g_variant_type_copy, g_variant_type_free)
+ #undef g_variant_type_get_type


### PR DESCRIPTION
As discussed in https://github.com/lovell/sharp-libvips/pull/106 - appears to apply cleanly when tested locally.