### PR TITLE
Fix warning about trailing whitespace

### DIFF
--- a/build/patches/mxe-fixes.patch
+++ b/build/patches/mxe-fixes.patch
@@ -244,14 +244,14 @@ index 1111111..2222222 100644
 -    (void)argv;
 +    ffi_arg rc;
  
-+    /* Initialize the argument info vectors */    
++    /* Initialize the argument info vectors */
      args[0] = &ffi_type_pointer;
      values[0] = &s;
  
 -    if (ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 1,
 -                           &ffi_type_uint, args) == FFI_OK)
 +    /* Initialize the cif */
-+    if (ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 1, 
++    if (ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 1,
 +                           &ffi_type_sint, args) == FFI_OK)
      {
          s = "Hello World!";
@@ -259,8 +259,8 @@ index 1111111..2222222 100644
 -        s = "Goodbye!";
 +        /* rc now holds the result of the call to puts */
 +
-+        /* values holds a pointer to the function's arg, so to 
-+           call puts() again all we need to do is change the 
++        /* values holds a pointer to the function's arg, so to
++           call puts() again all we need to do is change the
 +           value of s */
 +        s = "This is cool!";
          ffi_call(&cif, FFI_FN(puts), &rc, values);


### PR DESCRIPTION
This pull request fixes a warning which is emitted by [this](https://github.com/libvips/build-win64-mxe/blob/729819b452aa558c4f2f2aee341af9d7eb6e5b44/build/build.sh#L73-L76) step during the build process:

```
Step 6/6 : WORKDIR /data
 ---> Running in 193861089c4b
Removing intermediate container 193861089c4b
 ---> e319a8b65676
Successfully built e319a8b65676
Successfully tagged libvips-build-win-mxe:latest
Cloning into 'mxe'...
remote: Enumerating objects: 51009, done.
remote: Counting objects: 100% (491/491), done.
remote: Compressing objects: 100% (220/220), done.
remote: Total 51009 (delta 310), reused 426 (delta 271), pack-reused 50518
Receiving objects: 100% (51009/51009), 25.63 MiB | 10.28 MiB/s, done.
Resolving deltas: 100% (37178/37178), done.
Already up to date.
HEAD is now at 05dee73a Update sqlcipher to version 4.4.3
/data/patches/mxe-fixes.patch:247: trailing whitespace.
    /* Initialize the argument info vectors */
/data/patches/mxe-fixes.patch:254: trailing whitespace.
    if (ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 1,
/data/patches/mxe-fixes.patch:262: trailing whitespace.
        /* values holds a pointer to the function's arg, so to
/data/patches/mxe-fixes.patch:263: trailing whitespace.
           call puts() again all we need to do is change the
warning: 4 lines add whitespace errors.
```

