### PR TITLE
Select optimisation level per dependency

### DIFF
--- a/build/cgif.mk
+++ b/build/cgif.mk
@@ -10,6 +10,8 @@ $(PKG)_GH_CONF  := dloebl/cgif/tags,V
 $(PKG)_DEPS     := cc meson-wrapper
 
 define $(PKG)_BUILD
+    $(eval export CFLAGS += -O3)
+
     $(MXE_MESON_WRAPPER) \
         -Dtests=false \
         '$(SOURCE_DIR)' \

--- a/build/highway.mk
+++ b/build/highway.mk
@@ -13,6 +13,9 @@ $(PKG)_DEPS     := cc
 # Dynamic dispatch requires Linux to detect CPU capabilities on both Armv7
 # and AArch64.
 define $(PKG)_BUILD
+    $(eval export CFLAGS += -O3)
+    $(eval export CXXFLAGS += -O3)
+
     cd '$(BUILD_DIR)' && $(TARGET)-cmake \
         -DBUILD_TESTING=OFF \
         -DHWY_ENABLE_CONTRIB=OFF \

--- a/build/libheif.mk
+++ b/build/libheif.mk
@@ -9,6 +9,9 @@ $(PKG)_GH_CONF  := strukturag/libheif/releases,v
 $(PKG)_DEPS     := cc aom
 
 define $(PKG)_BUILD
+    $(eval export CFLAGS += -O3)
+    $(eval export CXXFLAGS += -O3)
+
     # Disable multithreading when building with Win32 threads to
     # avoid a dependency on mingw-std-threads (which we only use
     # in the "all" variant). Disabling multithreading only affects

--- a/build/libimagequant.mk
+++ b/build/libimagequant.mk
@@ -9,6 +9,8 @@ $(PKG)_GH_CONF  := lovell/libimagequant/tags,v
 $(PKG)_DEPS     := cc meson-wrapper
 
 define $(PKG)_BUILD
+    $(eval export CFLAGS += -O3)
+
     $(MXE_MESON_WRAPPER) '$(SOURCE_DIR)' '$(BUILD_DIR)'
 
     $(MXE_NINJA) -C '$(BUILD_DIR)' -j '$(JOBS)' install

--- a/build/libspng.mk
+++ b/build/libspng.mk
@@ -9,6 +9,8 @@ $(PKG)_GH_CONF  := randy408/libspng/tags,v
 $(PKG)_DEPS     := cc meson-wrapper zlib
 
 define $(PKG)_BUILD
+    $(eval export CFLAGS += -O3)
+
     # -Denable_opt=false is a workaround for:
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109504
     $(MXE_MESON_WRAPPER) \

--- a/build/overrides.mk
+++ b/build/overrides.mk
@@ -459,6 +459,8 @@ endef
 # build with -DCMS_RELY_ON_WINDOWS_STATIC_MUTEX_INIT to avoid a
 # horrible hack (we don't target pre-Windows XP, so it should be safe)
 define lcms_BUILD
+    $(eval export CFLAGS += -O3)
+
     $(MXE_MESON_WRAPPER) \
         -Djpeg=disabled \
         -Dtiff=disabled \

--- a/build/plugins/zlib-ng/zlib-ng.mk
+++ b/build/plugins/zlib-ng/zlib-ng.mk
@@ -9,6 +9,8 @@ $(PKG)_GH_CONF  := zlib-ng/zlib-ng/tags
 $(PKG)_DEPS     := cc
 
 define $(PKG)_BUILD
+    $(eval export CFLAGS += -O3)
+
     cd '$(BUILD_DIR)' && '$(TARGET)-cmake' \
         -DZLIB_COMPAT=ON \
         -DZLIB_ENABLE_TESTS=OFF \

--- a/build/settings/gcc-release.mk
+++ b/build/settings/gcc-release.mk
@@ -8,8 +8,10 @@
 MXE_TMP := /var/tmp
 
 # Special flags for compiler.
-export CFLAGS   := -s -O3 -fPIC
-export CXXFLAGS := -s -O3 -fPIC
+# Default optimisation level is for binary size (-Os).
+# Overriden to performance (-O3) for select dependencies that benefit.
+export CFLAGS   := -s -Os -fPIC
+export CXXFLAGS := -s -Os -fPIC
 export LDFLAGS  := -Wl,-s
 
 # Special flags for Rust.

--- a/build/settings/llvm-release.mk
+++ b/build/settings/llvm-release.mk
@@ -8,8 +8,10 @@
 MXE_TMP := /var/tmp
 
 # Special flags for compiler.
-export CFLAGS   := -O3 -g -gcodeview -fdata-sections -ffunction-sections
-export CXXFLAGS := -O3 -g -gcodeview -fdata-sections -ffunction-sections
+# Default optimisation level is for binary size (-Os).
+# Overriden to performance (-O3) for select dependencies that benefit.
+export CFLAGS   := -Os -g -gcodeview -fdata-sections -ffunction-sections
+export CXXFLAGS := -Os -g -gcodeview -fdata-sections -ffunction-sections
 export LDFLAGS  := -Wl,--pdb= -Wl,--gc-sections -Wl,-s
 
 # Special flags for Rust.

--- a/build/vips-all.mk
+++ b/build/vips-all.mk
@@ -76,6 +76,9 @@ endef
 define $(PKG)_BUILD
     $($(PKG)_PRE_CONFIGURE)
 
+    $(eval export CFLAGS += -O3)
+    $(eval export CXXFLAGS += -O3)
+
     $(MXE_MESON_WRAPPER) \
         -Ddeprecated=false \
         -Dexamples=false \

--- a/build/vips-web.mk
+++ b/build/vips-web.mk
@@ -59,6 +59,9 @@ endef
 define $(PKG)_BUILD
     $($(PKG)_PRE_CONFIGURE)
 
+    $(eval export CFLAGS += -O3)
+    $(eval export CXXFLAGS += -O3)
+
     # Always build as shared library, we need
     # libvips-42.dll for the language bindings.
     $(MXE_MESON_WRAPPER) \


### PR DESCRIPTION
Use a default optimisation level of `-Os`, selectively compile with `-O3` for dependencies that benefit.

Resolves: #55.

---

Here's a size comparison for the Windows x64 binaries (statically-linked "web" variant).

Before (commit 41e8e1c1cdef5e6e1e50e69b62cd7c1378cff82a):
```console
$ du -sbc *.dll
1184256		libglib-2.0-0.dll
243712		libgobject-2.0-0.dll
19117568	libvips-42.dll
456192		libvips-cpp-42.dll
21001728	total
```

After (this PR):
```console
$ du -sbc *.dll
1012736		libglib-2.0-0.dll
215552		libgobject-2.0-0.dll
17845248	libvips-42.dll
456192		libvips-cpp-42.dll
19529728	total
```

So, a ~7% reduction in binary size.