### PR TITLE
try adding an icon theme

### DIFF
--- a/build/nip4.mk
+++ b/build/nip4.mk
@@ -6,7 +6,7 @@ $(PKG)_VERSION  := 9.0.11
 $(PKG)_CHECKSUM := 6a4ea40987fbb79fe21207c0945114214d235995ed80d50ac54b479eaf0959e9
 $(PKG)_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/$(PKG)-[0-9]*.patch)))
 $(PKG)_GH_CONF  := jcupitt/nip4/releases,v,,,,.tar.xz
-$(PKG)_DEPS     := cc meson-wrapper gtk4 gsl vips-all
+$(PKG)_DEPS     := cc meson-wrapper gtk4 adwaita-icon-theme gsl vips-all
 
 define $(PKG)_PRE_CONFIGURE
     (printf '{\n'; \

--- a/build/nip4.mk
+++ b/build/nip4.mk
@@ -10,6 +10,7 @@ $(PKG)_DEPS     := cc meson-wrapper gtk4 adwaita-icon-theme gsl vips-all
 
 define $(PKG)_PRE_CONFIGURE
     (printf '{\n'; \
+     printf '  "adwaita-icon-theme": "$(adwaita-icon-theme_VERSION)",\n'; \
      printf '  "epoxy": "$(libepoxy_VERSION)",\n'; \
      printf '  "graphene": "$(graphene_VERSION)",\n'; \
      printf '  "gsl": "$(gsl_VERSION)",\n'; \

--- a/build/overrides.mk
+++ b/build/overrides.mk
@@ -175,6 +175,15 @@ gsl_FILE     := gsl-$(gsl_VERSION).tar.gz
 gsl_URL      := https://ftp.gnu.org/gnu/gsl/$(gsl_FILE)
 gsl_URL_2    := https://ftp.snt.utwente.nl/pub/software/gnu/gsl/$(gsl_FILE)
 
+# upstream version is 3.36.1
+# needed by nip4 and vipsdisp
+adwaita-icon-theme_VERSION  := 48.1
+adwaita-icon-theme_CHECKSUM := cbfe9b86ebcd14b03ba838c49829f7e86a7b132873803b90ac10be7d318a6e12
+adwaita-icon-theme_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/adwaita-icon-theme-[0-9]*.patch)))
+adwaita-icon-theme_SUBDIR   := adwaita-icon-theme-$(adwaita-icon-theme_VERSION)
+adwaita-icon-theme_FILE     := adwaita-icon-theme-$(adwaita-icon-theme_VERSION).tar.xz
+adwaita-icon-theme_URL      := https://download.gnome.org/sources/adwaita-icon-theme/$(firstword $(subst ., ,$(adwaita-icon-theme_VERSION)))/$(adwaita-icon-theme_FILE)
+
 ## Patches that we override with our own
 
 cairo_PATCHES := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/cairo-[0-9]*.patch)))
@@ -202,6 +211,9 @@ tiff_PATCHES := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))
 zlib_PATCHES := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/zlib-[0-9]*.patch)))
 
 ## Override sub-dependencies
+# adwaita-icon-theme:
+#  Added: meson-wrapper
+#  Removed: gettext
 # freetype:
 #  Added: meson-wrapper
 #  Removed: brotli, bzip2
@@ -257,6 +269,7 @@ zlib_PATCHES := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))
 #  Added: zlib
 #  Removed: dlfcn-win32
 
+adwaita-icon-theme_DEPS := $(subst gettext,meson-wrapper,$(adwaita-icon-theme_DEPS))
 freetype_DEPS           := $(subst brotli bzip2,meson-wrapper,$(freetype_DEPS))
 freetype-bootstrap_DEPS := $(subst brotli bzip2,meson-wrapper,$(freetype-bootstrap_DEPS))
 glib_DEPS               := cc meson-wrapper gettext libffi zlib
@@ -280,6 +293,13 @@ libarchive_DEPS         := cc zlib
 sqlite_DEPS             := cc zlib
 
 ## Override build scripts
+
+# build with the Meson build system
+define adwaita-icon-theme_BUILD
+    $(MXE_MESON_WRAPPER) '$(SOURCE_DIR)' '$(BUILD_DIR)'
+
+    $(MXE_NINJA) -C '$(BUILD_DIR)' -j '$(JOBS)' install
+endef
 
 # libasprintf isn't needed, so build with --disable-libasprintf
 # this definition is for reference purposes only, we use the

--- a/build/overrides.mk
+++ b/build/overrides.mk
@@ -574,6 +574,9 @@ define librsvg_BUILD
     # Disable tools
     $(SED) -i "/subdir('rsvg_convert')/d" '$(SOURCE_DIR)/meson.build'
 
+    # Ensure MXE's pkg-config wrapper finds librsvg-2.0-uninstalled.pc
+    $(SED) -i "s/PKG_CONFIG_PATH/&_$(subst .,_,$(subst -,_,$(TARGET)))/" '$(SOURCE_DIR)/meson/cargo_wrapper.py'
+
     $(MXE_MESON_WRAPPER) \
         -Dintrospection=disabled \
         -Dpixbuf=disabled \
@@ -583,6 +586,7 @@ define librsvg_BUILD
         -Dtests=false \
         -Dtriplet='$(PROCESSOR)-pc-windows-gnullvm' \
         -Dc_link_args='$(LDFLAGS) -lntdll -luserenv' \
+        $(librsvg_CONFIGURE_OPTS) \
         '$(SOURCE_DIR)' \
         '$(BUILD_DIR)'
 

--- a/build/patches/gdk-pixbuf-2-fixes.patch
+++ b/build/patches/gdk-pixbuf-2-fixes.patch
@@ -4,47 +4,8 @@ Contains ad hoc patches for cross building.
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kleis Auke Wolthuizen <github@kleisauke.nl>
-Date: Tue, 13 Oct 2020 16:40:45 +0200
-Subject: [PATCH 1/2] Don't force relocation support on Windows
-
-We don't use loadable modules for gdk-pixbuf.
-
-diff --git a/meson.build b/meson.build
-index 1111111..2222222 100644
---- a/meson.build
-+++ b/meson.build
-@@ -388,15 +388,8 @@ if not tiff_opt.disabled() and not native_windows_loaders
-   endif
- endif
- 
--# Determine whether we enable application bundle relocation support, and we use
--# this always on Windows
--if host_system == 'windows'
--  relocatable = (get_option('default_library') != 'static')
--else
--  relocatable = get_option('relocatable')
--endif
--
--if relocatable
-+# Determine whether we enable application bundle relocation support
-+if get_option('relocatable')
-   add_project_arguments([ '-DGDK_PIXBUF_RELOCATABLE' ], language: 'c')
- endif
- 
-@@ -474,7 +467,7 @@ summary({
-     'Introspection': build_gir,
-     'Documentation': build_docs,
-     'Manual pages': get_option('man'),
--    'Relocatable': relocatable,
-+    'Relocatable': get_option('relocatable'),
-     'Build tests': get_option('tests'),
-     'Installed tests': get_option('installed_tests'),
-   },
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Kleis Auke Wolthuizen <github@kleisauke.nl>
 Date: Mon, 7 Oct 2019 11:30:00 +0200
-Subject: [PATCH 2/2] Fix pkg-config file when using built-in loader(s)
+Subject: [PATCH 1/1] Fix pkg-config file when using built-in loader(s)
 
 See: https://gitlab.gnome.org/GNOME/gdk-pixbuf/merge_requests/50
 

--- a/build/patches/gdk-pixbuf-2-without-relocation.patch
+++ b/build/patches/gdk-pixbuf-2-without-relocation.patch
@@ -1,0 +1,42 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kleis Auke Wolthuizen <github@kleisauke.nl>
+Date: Tue, 13 Oct 2020 16:40:45 +0200
+Subject: [PATCH 1/1] Don't force relocation support on Windows
+
+We don't use loadable modules for gdk-pixbuf.
+
+diff --git a/meson.build b/meson.build
+index 1111111..2222222 100644
+--- a/meson.build
++++ b/meson.build
+@@ -388,15 +388,8 @@ if not tiff_opt.disabled() and not native_windows_loaders
+   endif
+ endif
+ 
+-# Determine whether we enable application bundle relocation support, and we use
+-# this always on Windows
+-if host_system == 'windows'
+-  relocatable = (get_option('default_library') != 'static')
+-else
+-  relocatable = get_option('relocatable')
+-endif
+-
+-if relocatable
++# Determine whether we enable application bundle relocation support
++if get_option('relocatable')
+   add_project_arguments([ '-DGDK_PIXBUF_RELOCATABLE' ], language: 'c')
+ endif
+ 
+@@ -474,7 +467,7 @@ summary({
+     'Introspection': build_gir,
+     'Documentation': build_docs,
+     'Manual pages': get_option('man'),
+-    'Relocatable': relocatable,
++    'Relocatable': get_option('relocatable'),
+     'Build tests': get_option('tests'),
+     'Installed tests': get_option('installed_tests'),
+   },

--- a/build/plugins/gtk4/overrides.mk
+++ b/build/plugins/gtk4/overrides.mk
@@ -15,4 +15,5 @@ cairo_CONFIGURE_OPTS = -Dzlib=enabled -Ddwrite=enabled
 libxml2_MESON_OPTS = -Doutput=enabled
 
 # Override sub-dependencies
+adwaita-icon-theme_DEPS := $(subst gtk3,gtk4,$(adwaita-icon-theme_DEPS))
 libepoxy_DEPS := $(filter-out  xorg-macros,$(libepoxy_DEPS))

--- a/build/plugins/gtk4/overrides.mk
+++ b/build/plugins/gtk4/overrides.mk
@@ -11,6 +11,12 @@ glib_CONFIGURE_OPTS = --force-fallback-for=libpcre2-8
 cairo_PATCHES := $(filter-out $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/../../patches/cairo-1-nanoserver-compat.patch))),$(cairo_PATCHES))
 cairo_CONFIGURE_OPTS = -Dzlib=enabled -Ddwrite=enabled
 
+# GTK requires a relocatable GDK-PixBuf plugin with SVG support.
+# TODO(kleisauke): Probably no longer needed in GTK >= 4.19.2.
+gdk-pixbuf_PATCHES := $(filter-out $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/../../patches/gdk-pixbuf-2-without-relocation.patch))),$(gdk-pixbuf_PATCHES))
+librsvg_DEPS := $(librsvg_DEPS) gdk-pixbuf
+librsvg_CONFIGURE_OPTS = -Dpixbuf=enabled -Dpixbuf-loader=enabled
+
 # nip4 needs -Doutput=enabled
 libxml2_MESON_OPTS = -Doutput=enabled
 

--- a/build/vipsdisp.mk
+++ b/build/vipsdisp.mk
@@ -2,12 +2,12 @@ PKG             := vipsdisp
 $(PKG)_WEBSITE  := https://github.com/jcupitt/vipsdisp
 $(PKG)_DESCR    := Tiny libvips / gtk+4 image viewer
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 4.1.1-test-gtk-svg-load
-$(PKG)_CHECKSUM := 90005b2c9cad3a45ad5b847fe72eac799579c4bc073cf471e14ef3c4d7a6d780
+$(PKG)_VERSION  := 4.1.2
+$(PKG)_CHECKSUM := 1f9edf4cf7b3abcccbd7cb61e63b8d9c8397db689dd3c937048fea7ca56d7b0c
 $(PKG)_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/$(PKG)-[0-9]*.patch)))
-$(PKG)_GH_CONF  := jcupitt/vipsdisp/releases,v,,,,-test-gtk4-svg.tar.xz
+$(PKG)_GH_CONF  := jcupitt/vipsdisp/releases,v,,,,.tar.xz
 $(PKG)_SUBDIR   := $(PKG)-$(firstword $(subst -, ,$($(PKG)_VERSION)))
-$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION)-test-gtk4-svg.tar.xz
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
 $(PKG)_DEPS     := cc meson-wrapper gtk4 adwaita-icon-theme vips-all 
 
 define $(PKG)_PRE_CONFIGURE

--- a/build/vipsdisp.mk
+++ b/build/vipsdisp.mk
@@ -6,8 +6,6 @@ $(PKG)_VERSION  := 4.1.2
 $(PKG)_CHECKSUM := 1f9edf4cf7b3abcccbd7cb61e63b8d9c8397db689dd3c937048fea7ca56d7b0c
 $(PKG)_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/$(PKG)-[0-9]*.patch)))
 $(PKG)_GH_CONF  := jcupitt/vipsdisp/releases,v,,,,.tar.xz
-$(PKG)_SUBDIR   := $(PKG)-$(firstword $(subst -, ,$($(PKG)_VERSION)))
-$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
 $(PKG)_DEPS     := cc meson-wrapper gtk4 adwaita-icon-theme vips-all 
 
 define $(PKG)_PRE_CONFIGURE

--- a/build/vipsdisp.mk
+++ b/build/vipsdisp.mk
@@ -2,12 +2,12 @@ PKG             := vipsdisp
 $(PKG)_WEBSITE  := https://github.com/jcupitt/vipsdisp
 $(PKG)_DESCR    := Tiny libvips / gtk+4 image viewer
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 4.1.1-windows-icon
-$(PKG)_CHECKSUM := 53db607dfb9d61c904514c4f64a7d5a5d856a451ba603b584868aea03c8a31f0
+$(PKG)_VERSION  := 4.1.1-test-gtk-svg-load
+$(PKG)_CHECKSUM := 90005b2c9cad3a45ad5b847fe72eac799579c4bc073cf471e14ef3c4d7a6d780
 $(PKG)_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/$(PKG)-[0-9]*.patch)))
-$(PKG)_GH_CONF  := jcupitt/vipsdisp/releases,v,,,,-windows-icon4.tar.xz
+$(PKG)_GH_CONF  := jcupitt/vipsdisp/releases,v,,,,-test-gtk4-svg.tar.xz
 $(PKG)_SUBDIR   := $(PKG)-$(firstword $(subst -, ,$($(PKG)_VERSION)))
-$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION)-test-gtk4-svg.tar.xz
 $(PKG)_DEPS     := cc meson-wrapper gtk4 adwaita-icon-theme vips-all 
 
 define $(PKG)_PRE_CONFIGURE

--- a/build/vipsdisp.mk
+++ b/build/vipsdisp.mk
@@ -7,11 +7,12 @@ $(PKG)_CHECKSUM := 53db607dfb9d61c904514c4f64a7d5a5d856a451ba603b584868aea03c8a3
 $(PKG)_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/$(PKG)-[0-9]*.patch)))
 $(PKG)_GH_CONF  := jcupitt/vipsdisp/releases,v,,,,-windows-icon4.tar.xz
 $(PKG)_SUBDIR   := $(PKG)-$(firstword $(subst -, ,$($(PKG)_VERSION)))
-$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION)-windows-icon4.tar.xz
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
 $(PKG)_DEPS     := cc meson-wrapper gtk4 adwaita-icon-theme vips-all 
 
 define $(PKG)_PRE_CONFIGURE
     (printf '{\n'; \
+     printf '  "adwaita-icon-theme": "$(adwaita-icon-theme_VERSION)",\n'; \
      printf '  "epoxy": "$(libepoxy_VERSION)",\n'; \
      printf '  "graphene": "$(graphene_VERSION)",\n'; \
      printf '  "gtk": "$(gtk4_VERSION)",\n'; \

--- a/build/vipsdisp.mk
+++ b/build/vipsdisp.mk
@@ -6,7 +6,7 @@ $(PKG)_VERSION  := 4.1.1
 $(PKG)_CHECKSUM := 2a3378ab2f0e427effdcaab5025580e60c2937b04bbecb2a1a9346adc48dbe10
 $(PKG)_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/$(PKG)-[0-9]*.patch)))
 $(PKG)_GH_CONF  := jcupitt/vipsdisp/releases,v,,,,.tar.xz
-$(PKG)_DEPS     := cc meson-wrapper gtk4 vips-all
+$(PKG)_DEPS     := cc meson-wrapper gtk4 adwaita-icon-theme vips-all 
 
 define $(PKG)_PRE_CONFIGURE
     (printf '{\n'; \

--- a/build/vipsdisp.mk
+++ b/build/vipsdisp.mk
@@ -2,10 +2,12 @@ PKG             := vipsdisp
 $(PKG)_WEBSITE  := https://github.com/jcupitt/vipsdisp
 $(PKG)_DESCR    := Tiny libvips / gtk+4 image viewer
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 4.1.1
-$(PKG)_CHECKSUM := 2a3378ab2f0e427effdcaab5025580e60c2937b04bbecb2a1a9346adc48dbe10
+$(PKG)_VERSION  := 4.1.1-windows-icon
+$(PKG)_CHECKSUM := 53db607dfb9d61c904514c4f64a7d5a5d856a451ba603b584868aea03c8a31f0
 $(PKG)_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/$(PKG)-[0-9]*.patch)))
-$(PKG)_GH_CONF  := jcupitt/vipsdisp/releases,v,,,,.tar.xz
+$(PKG)_GH_CONF  := jcupitt/vipsdisp/releases,v,,,,-windows-icon4.tar.xz
+$(PKG)_SUBDIR   := $(PKG)-$(firstword $(subst -, ,$($(PKG)_VERSION)))
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION)-windows-icon4.tar.xz
 $(PKG)_DEPS     := cc meson-wrapper gtk4 adwaita-icon-theme vips-all 
 
 define $(PKG)_PRE_CONFIGURE

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -5,6 +5,10 @@ FROM $BASE_IMAGE
 COPY . /data
 WORKDIR /usr/local/mxe
 
+# TODO(kleisauke): Move to the base image.
+# While we're at it, update the Docker container to Debian 13 (trixie) as well.
+RUN apt-get install -qqy --no-install-recommends gtk-update-icon-cache
+
 # libtool-specific patches for clang
 RUN patch -p1 -d /usr/share < /data/patches/libtool-2-fixes.patch
 

--- a/packaging/package-gtk.sh
+++ b/packaging/package-gtk.sh
@@ -137,6 +137,12 @@ rm -rf share/locale
 # Remove .gitkeep files
 rm -f share/.gitkeep
 
+# touch the icon theme root and cache to be newer than any icon it holds
+# prevents a "cache out of date" warning
+for theme in $install_dir/share/icons/*; do
+  touch -c $theme $theme/index.theme 
+done
+
 echo "Strip unneeded symbols"
 
 # Remove all symbols that are not needed

--- a/packaging/package-gtk.sh
+++ b/packaging/package-gtk.sh
@@ -58,11 +58,11 @@ module_dir_base=$(basename $module_dir)
 
 # Make sure that the repackaging dir is empty
 rm -rf $repackage_dir $pdb_dir
-mkdir -p $repackage_dir/bin
+mkdir -p $repackage_dir/{bin,lib}
 mkdir $pdb_dir
 
 # List of PE targets that need to be copied, including their transitive dependencies and PDBs
-pe_targets=($bin_dir/libvips-cpp-42.dll $bin_dir/{$package,gdbus}.exe)
+pe_targets=($bin_dir/libvips-cpp-42.dll $bin_dir/{$package,gdbus}.exe) # gdk-pixbuf-query-loaders
 
 # DLL search paths
 search_paths=($bin_dir $install_dir/${target%%.*}/bin)
@@ -118,6 +118,30 @@ echo "Copying install area $install_dir/"
 # Follow symlinks when copying /share and /etc directories
 cp -Lr $install_dir/{share,etc} $repackage_dir
 
+# Ensure pixbufloader_svg.dll is packaged
+cp -r $install_dir/lib/gdk-pixbuf-2.0 $repackage_dir/lib
+
+# ... and loaders.cache is created
+cat > $repackage_dir/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache << 'EOF'
+# GdkPixbuf Image Loader Modules file
+# Automatically generated file, do not edit
+# Created by gdk-pixbuf-query-loaders from gdk-pixbuf-2.43.3
+#
+# LoaderDir = lib\gdk-pixbuf-2.0\2.10.0\loaders
+#
+"lib\\gdk-pixbuf-2.0\\2.10.0\\loaders\\pixbufloader_svg.dll"
+"svg" 6 "gdk-pixbuf" "Scalable Vector Graphics" "LGPL"
+"image/svg+xml" "image/svg" "image/svg-xml" "image/vnd.adobe.svg+xml" "text/xml-svg" "image/svg+xml-compressed" ""
+"svg" "svgz" "svg.gz" ""
+" <svg" "*    " 100
+" <!DOCTYPE svg" "*             " 100
+
+EOF
+
+# TODO(kleisauke): Perhaps we should generate that natively or using wine?
+#wine $install_dir/bin/gdk-pixbuf-query-loaders.exe \
+#  $repackage_dir/lib/gdk-pixbuf-2.0/2.10.0/loaders/pixbufloader_svg.dll --update-cache
+
 cd $repackage_dir
 
 echo "Cleaning unnecessary files / directories"
@@ -136,6 +160,9 @@ rm -rf share/locale
 
 # Remove .gitkeep files
 rm -f share/.gitkeep
+
+# libpixbufloader-heif.dll is probably not needed
+rm -f $repackage_dir/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-heif.dll
 
 # touch the icon theme root and cache to be newer than any icon it holds
 # prevents a "cache out of date" warning


### PR DESCRIPTION
This kind-of works, you do get better icons, however:

- the fullscreen icon (top right of right-click menu) is still a placeholder (should be a pair of arrows pointing in opposite directions), despite the correct SVG being copied into the correct place in the build

- icons are not rendered with desktop scaling changes, so they get fuzzy at eg. 225% (this works correctly on my ubuntu fwiw)

- it'd be good to attach the vipsdisp icon to the generated exe as well, I suppose we need an ICO version of the PNG